### PR TITLE
:up: Update sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
         "popper.js": "^1.16",
         "postcss": "^8.4.14",
         "postcss-import": "^14.1.0",
-        "sass": "^1.54.0",
         "sass-loader": "^10.1.1",
         "tailwindcss": "^3.1.6",
         "turbolinks": "^5.2.0",
@@ -31,6 +30,7 @@
     },
     "dependencies": {
         "-": "^0.0.1",
+        "sass": "^1.83.0",
         "swiper": "^8.4.7"
     }
 }

--- a/resources/css/global.scss
+++ b/resources/css/global.scss
@@ -1,6 +1,6 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 @import "https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap";
 

--- a/resources/themes/atom/css/app.scss
+++ b/resources/themes/atom/css/app.scss
@@ -1,6 +1,6 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 @import "https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap";
 

--- a/resources/themes/dusk/css/app.scss
+++ b/resources/themes/dusk/css/app.scss
@@ -1,8 +1,6 @@
-@import 'tailwindcss/base';
-
-@import 'tailwindcss/components';
-
-@import 'tailwindcss/utilities';
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 @layer components {
     .dropdown-item {


### PR DESCRIPTION
This will remove the Deprecation Warning for sass:

Deprecation Warning: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
