### PR TITLE
feat(hk): RCON actions via housekeeping

### DIFF
--- a/app/Filament/Resources/Hotel/CatalogPageResource/Pages/ListCatalogPages.php
+++ b/app/Filament/Resources/Hotel/CatalogPageResource/Pages/ListCatalogPages.php
@@ -3,7 +3,10 @@
 namespace App\Filament\Resources\Hotel\CatalogPageResource\Pages;
 
 use App\Filament\Resources\Hotel\CatalogPageResource;
+use App\Services\RconService;
+use Filament\Actions\Action;
 use Filament\Actions\CreateAction;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
 
 class ListCatalogPages extends ListRecords
@@ -13,6 +16,28 @@ class ListCatalogPages extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('update-catalog')
+                ->label('Update catalog (RCON)')
+                ->color('danger')
+                ->action(function () {
+                    $rcon = app(RconService::class);
+                    if (!$rcon->isConnected()) {
+                        Notification::make()
+                            ->body(__('The RCON service is not connected.'))
+                            ->icon('heroicon-o-exclamation-circle')
+                            ->iconColor('danger')
+                            ->send();
+                        return;
+                    } else {
+                        $rcon->updateCatalog();
+                        Notification::make()
+                        ->body(__('The catalog has been successfully updated!'))
+                        ->icon('heroicon-o-check-circle')
+                        ->iconColor('success')
+                        ->send();
+                    }
+                }),
+
             CreateAction::make(),
         ];
     }

--- a/app/Filament/Resources/Hotel/EmulatorSettingResource/Pages/ListEmulatorSettings.php
+++ b/app/Filament/Resources/Hotel/EmulatorSettingResource/Pages/ListEmulatorSettings.php
@@ -3,8 +3,12 @@
 namespace App\Filament\Resources\Hotel\EmulatorSettingResource\Pages;
 
 use App\Filament\Resources\Hotel\EmulatorSettingResource;
-use Filament\Pages\Actions;
+use App\Services\RconService;
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Support\Facades\Auth;
 
 class ListEmulatorSettings extends ListRecords
 {
@@ -13,7 +17,29 @@ class ListEmulatorSettings extends ListRecords
     protected function getActions(): array
     {
         return [
-            Actions\CreateAction::make(),
+            Action::make('update-emulator-config')
+                ->label('Update settings (RCON)')
+                ->color('danger')
+                ->action(function () {
+                    $rcon = app(RconService::class);
+                    if (!$rcon->isConnected()) {
+                        Notification::make()
+                            ->body(__('The RCON service is not connected.'))
+                            ->icon('heroicon-o-exclamation-circle')
+                            ->iconColor('danger')
+                            ->send();
+                        return;
+                    } else {
+                        $rcon->updateConfig(Auth::user(), ':update_config');
+                        Notification::make()
+                        ->body(__('RCON executed! If you have the ":update_config" permission in-game, the emulator settings changes will now be live on the hotel.'))
+                        ->icon('heroicon-o-check-circle')
+                        ->iconColor('success')
+                        ->send();
+                    }
+                }),
+
+            CreateAction::make(),
         ];
     }
 }

--- a/app/Filament/Resources/Hotel/EmulatorTextResource/Pages/ManageEmulatorTexts.php
+++ b/app/Filament/Resources/Hotel/EmulatorTextResource/Pages/ManageEmulatorTexts.php
@@ -4,7 +4,11 @@ namespace App\Filament\Resources\Hotel\EmulatorTextResource\Pages;
 
 use Filament\Resources\Pages\ManageRecords;
 use App\Filament\Resources\Hotel\EmulatorTextResource;
+use App\Services\RconService;
+use Filament\Actions\Action;
 use Filament\Actions\CreateAction;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\Auth;
 
 class ManageEmulatorTexts extends ManageRecords
 {
@@ -13,6 +17,28 @@ class ManageEmulatorTexts extends ManageRecords
     protected function getActions(): array
     {
         return [
+            Action::make('update-emulator-texts')
+                ->label('Update texts (RCON)')
+                ->color('danger')
+                ->action(function () {
+                    $rcon = app(RconService::class);
+                    if (!$rcon->isConnected()) {
+                        Notification::make()
+                            ->body(__('The RCON service is not connected.'))
+                            ->icon('heroicon-o-exclamation-circle')
+                            ->iconColor('danger')
+                            ->send();
+                        return;
+                    } else {
+                        $rcon->updateConfig(Auth::user(), ':update_texts');
+                        Notification::make()
+                        ->body(__('RCON executed! If you have the ":update_texts" permission in-game, the emulator texts changes will now be live on the hotel.'))
+                        ->icon('heroicon-o-check-circle')
+                        ->iconColor('success')
+                        ->send();
+                    }
+                }),
+
             CreateAction::make('create')
         ];
     }

--- a/app/Filament/Resources/Hotel/WordFilterResource/Pages/ManageWordFilters.php
+++ b/app/Filament/Resources/Hotel/WordFilterResource/Pages/ManageWordFilters.php
@@ -3,7 +3,10 @@
 namespace App\Filament\Resources\Hotel\WordFilterResource\Pages;
 
 use App\Filament\Resources\Hotel\WordFilterResource;
-use Filament\Pages\Actions;
+use App\Services\RconService;
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ManageRecords;
 
 class ManageWordFilters extends ManageRecords
@@ -13,7 +16,29 @@ class ManageWordFilters extends ManageRecords
     protected function getActions(): array
     {
         return [
-            Actions\CreateAction::make(),
+            Action::make('update-wordfilter')
+                ->label('Update wordfilter (RCON)')
+                ->color('danger')
+                ->action(function () {
+                    $rcon = app(RconService::class);
+                    if (!$rcon->isConnected()) {
+                        Notification::make()
+                            ->body(__('The RCON service is not connected.'))
+                            ->icon('heroicon-o-exclamation-circle')
+                            ->iconColor('danger')
+                            ->send();
+                        return;
+                    } else {
+                        $rcon->updateWordFilter();
+                        Notification::make()
+                        ->body(__('The wordfilter has been successfully updated!'))
+                        ->icon('heroicon-o-check-circle')
+                        ->iconColor('success')
+                        ->send();
+                    }
+                }),
+
+            CreateAction::make(),
         ];
     }
 }


### PR DESCRIPTION
This PR aims to integrate RCON-supported actions through housekeeping, such as updating catalog, emulators configs and text, and wordfilters. This PR also can be a starting point for future developers and contributors to integrate RCON-supported actions on their custom features.