### PR TITLE
fix(hk): Housekeeping Permissions inputs fixes

### DIFF
--- a/app/Filament/Resources/Atom/HousekeepingPermissionResource.php
+++ b/app/Filament/Resources/Atom/HousekeepingPermissionResource.php
@@ -4,9 +4,11 @@ namespace App\Filament\Resources\Atom;
 
 use App\Filament\Resources\Atom\HousekeepingPermissionResource\Pages;
 use App\Filament\Resources\Atom\HousekeepingPermissionResource\RelationManagers;
+use App\Models\Game\Permission;
 use App\Models\WebsiteHousekeepingPermission;
 use Filament\Forms;
 use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
@@ -43,11 +45,10 @@ class HousekeepingPermissionResource extends Resource
                         ->unique(ignoreRecord: true)
                         ->required(),
 
-                    TextInput::make('min_rank')
+                    Select::make('min_rank')
+                        ->native(false)
                         ->label(__('filament::resources.inputs.min_rank'))
-                        ->required()
-                        ->maxLength(255)
-                        ->autocomplete(),
+                        ->options(Permission::get()->pluck('rank_name', 'id')),
 
                     TextInput::make('description')
                         ->label(__('filament::resources.inputs.description'))
@@ -71,9 +72,10 @@ class HousekeepingPermissionResource extends Resource
                     ->label(__('filament::resources.columns.permission'))
                     ->searchable(),
 
-                TextColumn::make('min_rank')
+                TextColumn::make('permission.rank_name')
                     ->label(__('filament::resources.columns.min_rank'))
                     ->searchable()
+                    ->sortable()
                     ->limit(30),
 
                 TextColumn::make('description')

--- a/app/Filament/Resources/Atom/HousekeepingPermissionResource.php
+++ b/app/Filament/Resources/Atom/HousekeepingPermissionResource.php
@@ -25,7 +25,7 @@ class HousekeepingPermissionResource extends Resource
     protected static ?string $navigationGroup = 'Website';
 
     protected static ?string $slug = 'website/housekeeping-permissions';
-    
+
     protected static ?string $navigationLabel = 'Housekeeping permissions';
 
     public static string $translateIdentifier = 'housekeeping-permissions';
@@ -38,7 +38,7 @@ class HousekeepingPermissionResource extends Resource
                 ->schema([
                     TextInput::make('permission')
                         ->label(__('filament::resources.inputs.permission'))
-                        ->maxLength(50)
+                        ->maxLength(255)
                         ->autocomplete()
                         ->unique(ignoreRecord: true)
                         ->required(),

--- a/app/Models/WebsiteHousekeepingPermission.php
+++ b/app/Models/WebsiteHousekeepingPermission.php
@@ -2,9 +2,16 @@
 
 namespace App\Models;
 
+use App\Models\Game\Permission;
 use Illuminate\Database\Eloquent\Model;
 
 class WebsiteHousekeepingPermission extends Model
 {
     protected $guarded = ['id'];
+
+    public function permission()
+    {
+        return $this->belongsTo(Permission::class, 'min_rank');
+    }
 }
+


### PR DESCRIPTION
This PR aims to fix input columns related to permission keys, and min_rank.

- Character limit for permission keys have been increased from 50 to 255 to avoid future issues related to long permission keys.
- Modified min_rank text input to selectable ranks dropdown, as previously I didn't code proper checks for the text input, also by using selectable ranks dropdown, administrators no longer need to look up and input rank ID to create or modify housekeeping permissions