### PR TITLE
⬆️ Fix lost theme settings that causeing 500 / 419 errors in some cases

### DIFF
--- a/app/Helpers/helper.php
+++ b/app/Helpers/helper.php
@@ -14,9 +14,9 @@ if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
 }
 
 if (! function_exists('setting')) {
-    function setting(string $setting): string
+    function setting(string $key, mixed $default = null): mixed
     {
-        return app(SettingsService::class)->getOrDefault($setting);
+        return app(SettingsService::class)->getOrDefault($key, $default);
     }
 }
 

--- a/app/Models/Miscellaneous/WebsiteSetting.php
+++ b/app/Models/Miscellaneous/WebsiteSetting.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Miscellaneous;
 
+use App\Services\SettingsService;
 use Illuminate\Database\Eloquent\Model;
 
 class WebsiteSetting extends Model
@@ -9,4 +10,10 @@ class WebsiteSetting extends Model
     protected $guarded = [];
 
     public $timestamps = false;
+
+    protected static function booted()
+    {
+        static::saved(fn () => SettingsService::clearCache());
+        static::deleted(fn () => SettingsService::clearCache());
+    }
 }

--- a/app/Services/Community/StaffService.php
+++ b/app/Services/Community/StaffService.php
@@ -26,7 +26,7 @@ class StaffService
             ->where('id', '>=', setting('min_staff_rank'))
             ->orderByDesc('id')
             ->with(['users' => function ($query) {
-                $query->select('id', 'username', 'rank', 'look', 'hidden_staff', 'online')
+                $query->select('id', 'username', 'rank', 'motto', 'look', 'hidden_staff', 'online')
                     ->when(Auth::user()->rank < (int) setting('min_rank_to_see_hidden_staff'), function ($query) {
                         return $query->where('hidden_staff', false);
                     });

--- a/resources/themes/atom/views/components/top-header.blade.php
+++ b/resources/themes/atom/views/components/top-header.blade.php
@@ -53,7 +53,13 @@
         @endif
 
         <x-navigation.dropdown classes="!border-none">
-            <img class="h-12" src="{{ setting('avatar_imager') }}{{ auth()->user()->look }}&direction=2&headonly=1&head_direction=2&gesture=sml" alt="{{ auth()->user()->username }}">
+            <div @class([
+                    '!bg-no-repeat !bg-center',
+                    'w-[54px] h-[62px]' => Str::contains(setting('avatar_imager'), 'www.habbo.com'),
+                    'w-[64px] h-[110px]' => !Str::contains(setting('avatar_imager'), 'www.habbo.com'),
+                ])
+                style="background: url({{ setting('avatar_imager') }}{{ auth()->user()->look }}&direction=2&headonly=1&head_direction=2&gesture=sml)">
+            </div>
 
             <span class="-ml-2">{{ auth()->user()->username }}</span>
 


### PR DESCRIPTION
This will fix the following error:

resources/themes//css/app.scss. {"view":{"view":"/var/www/Test-CMS/resources/themes/atom/views/layouts/app.blade.php","data":[]},"exception":"[object] (Spatie\\LaravelIgnition\\Exceptions\\ViewException(code: 0): Unable to locate file in Vite manifest: resources/themes//css/app.scss. at /var/www//Test-CMS/vendor/laravel/framework/src/Illuminate/Foundation/Vite.php:988)

As in the current state the cache will be hardcoded 5 min. and this way it will cache forever unless a change is made