### PR TITLE
fix(testing): environment database credentials

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,8 +16,6 @@
     <env name="DB_HOST" value="127.0.0.1"/>
     <env name="DB_PORT" value="3306"/>
     <env name="DB_DATABASE" value="testing"/>
-    <env name="DB_USERNAME" value="root"/>
-    <env name="DB_PASSWORD" value="password"/>
     <env name="MAIL_MAILER" value="array"/>
     <env name="QUEUE_CONNECTION" value="sync"/>
     <env name="SESSION_DRIVER" value="array"/>


### PR DESCRIPTION
The PHPUnit configuration hard-coded MySQL root credentials, causing local
test runs to fail when the server uses a different authentication setup.

- Remove `DB_USERNAME` and `DB_PASSWORD` from `phpunit.xml` so tests use
  credentials supplied by the environment.