### PR TITLE
fix(blaze): target theme component views

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -93,8 +93,8 @@ class AppServiceProvider extends ServiceProvider
         Model::preventLazyLoading(! $this->app->isProduction());
 
         Blaze::optimize()
-            ->in(resource_path('themes/atom/components'))
-            ->in(resource_path('themes/dusk/components'));
+            ->in(resource_path('themes/atom/views/components'))
+            ->in(resource_path('themes/dusk/views/components'));
 
         if (config('habbo.site.force_https')) {
             URL::forceScheme('https');


### PR DESCRIPTION
Blaze optimization being silently disabled because
`AppServiceProvider::boot()` registered theme component directories without
the `views` segment, causing Blaze to skip every Atom and Dusk component.

- Point `Blaze::optimize()` at
  `resources/themes/{atom,dusk}/views/components` so both themes' Blade
  components enter Blaze compilation.