### PR TITLE
fix(filament): wire login and dashboard

### DIFF
--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -16,11 +16,4 @@ class Dashboard extends FilamentDashboard
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-home';
 
     public static string $translateIdentifier = 'dashboard';
-
-    public static string $roleName = 'dashboard';
-
-    public static function canAccess(): bool
-    {
-        return auth()->user()?->can('view::admin::' . static::$roleName) ?? false;
-    }
 }

--- a/app/Filament/Pages/Login.php
+++ b/app/Filament/Pages/Login.php
@@ -2,99 +2,19 @@
 
 namespace App\Filament\Pages;
 
-use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
-use Filament\Auth\Http\Responses\Contracts\LoginResponse;
-use Filament\Facades\Filament;
-use Filament\Forms\Components\Checkbox;
+use Filament\Auth\Pages\Login as FilamentLogin;
 use Filament\Forms\Components\TextInput;
-use Filament\Models\Contracts\FilamentUser;
-use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Component;
-use Illuminate\Support\Facades\Lang;
 use Illuminate\Validation\ValidationException;
+use SensitiveParameter;
 
-class Login extends \Filament\Auth\Pages\Login
+class Login extends FilamentLogin
 {
-    public string $username = '';
-
-    public function authenticate(): ?LoginResponse
-    {
-        try {
-            $this->rateLimit(5);
-        } catch (TooManyRequestsException $exception) {
-            Notification::make()
-                ->title(__('filament-panels::pages/auth/login.notifications.throttled.title', [
-                    'seconds' => $exception->secondsUntilAvailable,
-                    'minutes' => ceil($exception->secondsUntilAvailable / 60),
-                ]))
-                ->body($this->throttledNotificationBody($exception))
-                ->danger()
-                ->send();
-
-            return null;
-        }
-
-        $data = $this->form->getState();
-
-        if (! Filament::auth()->attempt($this->getCredentialsFromFormData($data), $data['remember'] ?? false)) {
-            $this->throwFailureValidationException();
-        }
-
-        $user = Filament::auth()->user();
-        $panel = Filament::getCurrentOrDefaultPanel();
-
-        if (
-            ($user instanceof FilamentUser) &&
-            ($panel === null || ! $user->canAccessPanel($panel))
-        ) {
-            Filament::auth()->logout();
-
-            $this->throwFailureValidationException();
-        }
-
-        session()->regenerate();
-
-        return app(LoginResponse::class);
-    }
-
     protected function throwFailureValidationException(): never
     {
         throw ValidationException::withMessages([
-            'data.username' => __('filament-panels::pages/auth/login.messages.failed'),
+            'data.username' => __('filament-panels::auth/pages/login.messages.failed'),
         ]);
-    }
-
-    private function throttledNotificationBody(TooManyRequestsException $exception): ?string
-    {
-        $key = 'filament-panels::pages/auth/login.notifications.throttled.body';
-
-        if (! Lang::has($key)) {
-            return null;
-        }
-
-        $body = __($key, [
-            'seconds' => $exception->secondsUntilAvailable,
-            'minutes' => ceil($exception->secondsUntilAvailable / 60),
-        ]);
-
-        return is_string($body) ? $body : null;
-    }
-
-    /** @return array<int, Component> */
-    protected function getFormSchema(): array
-    {
-        return [
-            TextInput::make('username')
-                ->label(__('filament::login.fields.username.label'))
-                ->required()
-                ->autocomplete(),
-            TextInput::make('password')
-                ->label(__('filament::login.fields.password.label'))
-                ->password()
-                ->required(),
-            Checkbox::make('remember')
-                ->label(__('filament::login.fields.remember.label')),
-        ];
     }
 
     protected function getEmailFormComponent(): Component
@@ -112,7 +32,7 @@ class Login extends \Filament\Auth\Pages\Login
      *
      * @return array<string, mixed>
      */
-    protected function getCredentialsFromFormData(array $data): array
+    protected function getCredentialsFromFormData(#[SensitiveParameter] array $data): array
     {
         return [
             'username' => $data['username'],

--- a/app/Providers/Filament/AdminFilamentPanelProvider.php
+++ b/app/Providers/Filament/AdminFilamentPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Pages\Login;
 use App\Http\Middleware\BannedMiddleware;
 use App\Http\Middleware\ForceStaffTwoFactorMiddleware;
 use App\Http\Middleware\MaintenanceMiddleware;
@@ -9,7 +10,6 @@ use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
-use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
@@ -31,16 +31,14 @@ class AdminFilamentPanelProvider extends PanelProvider
             ->id('housekeeping')
             ->path('housekeeping')
             ->strictAuthorization()
-            ->login()
+            ->login(Login::class)
             ->viteTheme('resources/css/filament/housekeeping/theme.css')
             ->colors([
                 'primary' => Color::Amber,
             ])
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
-            ->pages([
-                Dashboard::class,
-            ])
+            ->pages([])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->widgets([
                 AccountWidget::class,

--- a/tests/Feature/HousekeepingAccessTest.php
+++ b/tests/Feature/HousekeepingAccessTest.php
@@ -1,12 +1,17 @@
 <?php
 
+use App\Filament\Pages\Dashboard;
+use App\Filament\Pages\Login;
 use App\Models\Miscellaneous\WebsitePermission;
 use App\Models\User;
 use App\Models\User\Ban;
 use App\Models\WebsiteHousekeepingPermission;
 use App\Policies\BanPolicy;
 use App\Policies\WebsiteHelpCenterTicketPolicy;
+use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
+use Livewire\Livewire;
 
 function grantHousekeepingPermission(string $permission, int $minRank): void
 {
@@ -21,6 +26,43 @@ test('guests are redirected away from the housekeeping panel', function () {
     installHotel();
 
     $this->get('/housekeeping')->assertRedirect();
+});
+
+test('housekeeping routes use the application login and dashboard pages', function () {
+    expect(Route::getRoutes()->getByName('filament.housekeeping.auth.login')?->getActionName())
+        ->toBe(Login::class)
+        ->and(Route::getRoutes()->getByName('filament.housekeeping.pages.dashboard')?->getActionName())
+        ->toBe(Dashboard::class);
+});
+
+test('staff can log into housekeeping with their username', function () {
+    installHotel();
+    grantHousekeepingPermission('can_access_housekeeping', 6);
+
+    $staff = User::factory()->create(['rank' => 6]);
+
+    Filament::setCurrentPanel(Filament::getPanel('housekeeping'));
+
+    Livewire::test(Login::class)
+        ->set('data.username', $staff->username)
+        ->set('data.password', 'password')
+        ->set('data.remember', false)
+        ->call('authenticate')
+        ->assertHasNoErrors();
+
+    $this->assertAuthenticatedAs($staff);
+});
+
+test('staff with housekeeping access can view the dashboard', function () {
+    installHotel();
+    grantHousekeepingPermission('can_access_housekeeping', 6);
+    setSetting('force_staff_2fa', '0');
+
+    $staff = User::factory()->create(['rank' => 6]);
+
+    $this->actingAs($staff)
+        ->get('/housekeeping')
+        ->assertOk();
 });
 
 test('users without the housekeeping permission are forbidden', function () {


### PR DESCRIPTION
The housekeeping panel used Filament's vendor login, which queried the
nonexistent `users.email` column, while the vendor Dashboard shadowed the
application page.

- register `App\Filament\Pages\Login` in
  `AdminFilamentPanelProvider` and let page discovery provide the custom
  Dashboard
- retain username credentials while inheriting Filament 5.6's authentication
  pipeline, including timeboxing, events, MFA, and panel-access checks
- remove the undefined `view::admin::dashboard` Gate check and rely on
  `User::canAccessPanel()` with `can_access_housekeeping`
- cover route bindings, username authentication, and authorized Dashboard
  access in `HousekeepingAccessTest`; `composer analyse` passes, while
  `composer test` is blocked before assertions by the test database's
  unsupported `auth_gssapi_client` requirement