### PR TITLE
fix(database): stop colliding with the emulator on a shared database

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ composer setup
 
 The installer asks which emulator you use. Arcturus imports the bundled base SQL automatically. For Ada, start the emulator once first so its EF migrations create the database, then run `php artisan atom:install --emulator=ada` against that same database. The installer then activates and builds your chosen theme. When it finishes, serve the site and visit `/installation` to configure your hotel.
 
+The installer never writes over a database it did not build. If the target already holds an emulator's schema - Arcturus tables, Polaris' Flyway history, or Ada's Entity Framework history - the base import is refused rather than offered, `--fresh` included. Point Atom at that same database with `--skip-arcturus` (or the matching `--emulator`) and it adds only its own tables. Atom keeps its password reset tokens in `website_password_resets` for the same reason: `password_resets` belongs to the emulator, and an existing one is left untouched.
+
 Docker Compose includes separate `mariadb` and `mariadb-ada` services with independent volumes, so testing Ada never requires clearing the Arcturus database. Use `mariadb-ada:3306` from another Compose service, or `127.0.0.1:3308` from the host. The default Ada database and credentials are `atomcms_ada`, `atomcms`, and `password`. Point Ada at it first so EF applies its migrations, then set Atom to the same database with `EMULATOR_DRIVER=ada`.
 
 Useful variations:
@@ -106,7 +108,7 @@ php artisan atom:install                            # Re-run just the installer 
 php artisan atom:install --sql=/path/to/db.sql      # Use your own Arcturus dump (.sql or .sql.gz)
 php artisan atom:install --emulator=ada             # Install against an EF-migrated Ada database
 php artisan atom:install --catalog-sql=/path/to.sql # Use your own catalog dump on top of the base
-php artisan atom:install --fresh                    # Clear the target database first (destroys existing data)
+php artisan atom:install --fresh                    # Clear the target database first (destroys existing data, refused on a hotel)
 php artisan atom:install --skip-catalog             # Keep the stock catalog from the base database
 php artisan atom:install --skip-arcturus            # Skip the base database + catalog import entirely
 php artisan atom:install --theme=dusk               # Pick the theme without being asked

--- a/app/Emulator/Drivers/Arcturus/ArcturusInstaller.php
+++ b/app/Emulator/Drivers/Arcturus/ArcturusInstaller.php
@@ -3,6 +3,8 @@
 namespace App\Emulator\Drivers\Arcturus;
 
 use App\Emulator\Contracts\EmulatorInstaller;
+use App\Enums\HotelSchemaState;
+use App\Support\HotelSchemaPreflight;
 use Generator;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
@@ -59,7 +61,19 @@ class ArcturusInstaller implements EmulatorInstaller
             return false;
         }
 
-        if (! $this->ensureEmptyDatabase($command)) {
+        $schema = HotelSchemaPreflight::inspect();
+
+        if ($schema->state === HotelSchemaState::Hotel) {
+            error('This database already belongs to an emulator that built it itself - importing the Arcturus base over it would destroy the hotel.');
+            note(
+                'Emulators that manage their own schema (Polaris through Flyway, Ada through Entity Framework)' . PHP_EOL
+                . 'need no base import. Install with --skip-arcturus, or with the --emulator matching the one running here.',
+            );
+
+            return false;
+        }
+
+        if (! $this->ensureEmptyDatabase($command, $schema)) {
             return false;
         }
 
@@ -83,16 +97,25 @@ class ArcturusInstaller implements EmulatorInstaller
      * run collide with the dump's CREATE TABLE statements, and a half-imported
      * database is the state this whole class exists to avoid. Offer to clear
      * it, but never without being told to.
+     *
+     * A database an emulator manages never reaches here - `prepare()` refuses
+     * it outright - so what is left is Atom's own tables, or leftovers nobody
+     * claims. Both are the operator's call, not Atom's.
      */
-    private function ensureEmptyDatabase(Command $command): bool
+    private function ensureEmptyDatabase(Command $command, HotelSchemaPreflight $schema): bool
     {
-        $tables = $this->tables();
-
-        if ($tables === []) {
+        if ($schema->tables === []) {
             return true;
         }
 
-        warning(sprintf('The database already contains %d table(s).', count($tables)));
+        warning(sprintf('The database already contains %d table(s).', count($schema->tables)));
+
+        if ($schema->unrecognised !== []) {
+            note(
+                'These were not created by Atom: ' . implode(', ', array_slice($schema->unrecognised, 0, 5))
+                . (count($schema->unrecognised) > 5 ? sprintf(' and %d more', count($schema->unrecognised) - 5) : ''),
+            );
+        }
 
         $clear = (bool) $command->option('fresh') || (
             ! $command->option('no-interaction') && confirm(
@@ -148,15 +171,6 @@ class ArcturusInstaller implements EmulatorInstaller
         info(ucfirst($label) . ' imported.');
 
         return true;
-    }
-
-    /** @return list<string> */
-    private function tables(): array
-    {
-        return array_values(array_map(
-            fn (array $table): string => (string) $table['name'],
-            Schema::getTables(),
-        ));
     }
 
     private function dropAllTables(): void

--- a/app/Enums/HotelSchemaState.php
+++ b/app/Enums/HotelSchemaState.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * How a database looks to Atom before it imports anything into it.
+ */
+enum HotelSchemaState: string
+{
+    /** No tables at all - Atom may import the bundled base database. */
+    case Fresh = 'fresh';
+
+    /** Only tables Atom creates itself - the emulator schema is still missing. */
+    case AtomOnly = 'atom-only';
+
+    /** A recognised Arcturus/Polaris hotel that is already set up - import nothing. */
+    case Hotel = 'hotel';
+
+    /** Non-empty and unrecognised - it belongs to something else. */
+    case Unknown = 'unknown';
+
+    /**
+     * Whether importing the bundled Arcturus dump - which drops and recreates
+     * every table it ships - can be done without destroying someone's data.
+     */
+    public function safeToImport(): bool
+    {
+        return $this === self::Fresh || $this === self::AtomOnly;
+    }
+}

--- a/app/Models/PasswordResetToken.php
+++ b/app/Models/PasswordResetToken.php
@@ -23,6 +23,9 @@ use Illuminate\Support\Carbon;
  */
 class PasswordResetToken extends Model
 {
+    // Namespaced away from `password_resets`, which emulators own.
+    protected $table = 'website_password_resets';
+
     protected $primaryKey = 'token';
 
     public $incrementing = false;

--- a/app/Support/HotelSchemaPreflight.php
+++ b/app/Support/HotelSchemaPreflight.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace App\Support;
+
+use App\Enums\HotelSchemaState;
+use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Inspects a database before Atom writes anything into it.
+ *
+ * The bundled Arcturus dump opens with `DROP TABLE IF EXISTS` for all 122 tables
+ * it ships, so importing it into a database that already belongs to an emulator -
+ * Polaris runs its own migrations and owns the whole schema up front - destroys a
+ * live hotel. This is the gate that stops that, and it mirrors the equivalent
+ * check Polaris runs before it migrates (`SchemaPreflight`).
+ *
+ * The hotel signature is deliberately compact rather than an exact dump match:
+ * hotels add plugin tables and custom columns all the time, and those must still
+ * be recognised as a hotel instead of being treated as a stranger's database.
+ */
+final class HotelSchemaPreflight
+{
+    /**
+     * Characteristic tables per emulator family, and the columns that identify
+     * them. A signature entry with no columns is matched on the table name
+     * alone. Matching any one signature in full makes the database a hotel.
+     *
+     * @var array<string, array<string, list<string>>>
+     */
+    private const HOTEL_SIGNATURES = [
+        'Arcturus' => [
+            'users' => ['id', 'username', 'password', 'auth_ticket'],
+            'rooms' => ['id', 'owner_id', 'model'],
+            'items' => ['id', 'user_id', 'room_id', 'item_id'],
+            'items_base' => ['id', 'interaction_type'],
+            'catalog_pages' => ['id', 'page_layout'],
+            'emulator_settings' => ['key', 'value'],
+            'permissions' => ['id', 'rank_name'],
+            'users_currency' => ['user_id', 'type', 'amount'],
+        ],
+        // Ada builds these through Entity Framework. Only the table names are
+        // checked: its columns move between EF migrations, and a false negative
+        // here costs a live hotel.
+        'Ada' => [
+            'players' => [],
+            'player_data' => [],
+            'player_avatar_data' => [],
+            'player_website_data' => [],
+            'roles' => [],
+            'badges' => [],
+        ],
+    ];
+
+    /**
+     * Where emulators record their own migration history - Polaris through
+     * Flyway, Ada through Entity Framework. Either one means an emulator
+     * already manages this schema, whatever state the rest of it is in.
+     *
+     * @var list<string>
+     */
+    private const EMULATOR_MIGRATION_TABLES = ['flyway_schema_history', '__efmigrationshistory'];
+
+    /** @var list<string> */
+    private const ATOM_TABLE_PREFIXES = ['website_', 'user_home_', 'telescope_'];
+
+    /**
+     * Tables Atom creates itself, either through its own migrations or through
+     * the framework and packages it ships.
+     *
+     * @var list<string>
+     */
+    private const ATOM_TABLES = [
+        'activity_log',
+        'cache',
+        'cache_locks',
+        'claimed_referral_logs',
+        'failed_jobs',
+        'home_categories',
+        'home_items',
+        'job_batches',
+        'jobs',
+        'migrations',
+        'password_reset_tokens',
+        'personal_access_tokens',
+        'referrals',
+        'sessions',
+        'taggables',
+        'tags',
+        'user_referrals',
+        'users_session_logs',
+    ];
+
+    /**
+     * @param  list<string>  $tables  Every base table found in the database.
+     * @param  list<string>  $unrecognised  Tables that belong to neither Atom nor a hotel.
+     * @param  list<string>  $missingSignature  Hotel tables/columns that were looked for and not found.
+     */
+    private function __construct(
+        public readonly HotelSchemaState $state,
+        public readonly array $tables,
+        public readonly array $unrecognised,
+        public readonly array $missingSignature,
+    ) {}
+
+    public static function inspect(?string $connection = null): self
+    {
+        $schema = Schema::connection($connection);
+
+        $tables = array_values(array_map(
+            fn (array $table): string => strtolower((string) $table['name']),
+            $schema->getTables(),
+        ));
+
+        if ($tables === []) {
+            return new self(HotelSchemaState::Fresh, [], [], []);
+        }
+
+        foreach (self::EMULATOR_MIGRATION_TABLES as $table) {
+            if (in_array($table, $tables, true)) {
+                return new self(HotelSchemaState::Hotel, $tables, [], []);
+            }
+        }
+
+        $missing = self::missingSignature($schema, $tables);
+
+        if ($missing === []) {
+            return new self(HotelSchemaState::Hotel, $tables, [], []);
+        }
+
+        $unrecognised = array_values(array_filter(
+            $tables,
+            fn (string $table): bool => ! self::isAtomTable($table),
+        ));
+
+        return new self(
+            $unrecognised === [] ? HotelSchemaState::AtomOnly : HotelSchemaState::Unknown,
+            $tables,
+            $unrecognised,
+            $missing,
+        );
+    }
+
+    /**
+     * What the database is missing from the signature it comes closest to. Empty
+     * when it matches one in full, in which case it is a hotel.
+     *
+     * @param  list<string>  $tables
+     *
+     * @return list<string>
+     */
+    private static function missingSignature(Builder $schema, array $tables): array
+    {
+        $closest = null;
+        $closestFound = -1;
+
+        foreach (self::HOTEL_SIGNATURES as $signature) {
+            $missing = self::missingFrom($schema, $tables, $signature);
+
+            if ($missing === []) {
+                return [];
+            }
+
+            // Whichever family the database has the most tables of is the one
+            // worth reporting against - a half-built Arcturus is missing fewer
+            // Ada tables than Arcturus ones purely because Ada's list is shorter.
+            $found = count(array_intersect(array_keys($signature), $tables));
+
+            if ($found > $closestFound) {
+                $closest = $missing;
+                $closestFound = $found;
+            }
+        }
+
+        return $closest ?? [];
+    }
+
+    /**
+     * @param  list<string>  $tables
+     * @param  array<string, list<string>>  $signature
+     *
+     * @return list<string>
+     */
+    private static function missingFrom(Builder $schema, array $tables, array $signature): array
+    {
+        $missing = [];
+
+        foreach ($signature as $table => $columns) {
+            if (! in_array($table, $tables, true)) {
+                $missing[] = $table;
+
+                continue;
+            }
+
+            foreach ($columns as $column) {
+                if (! $schema->hasColumn($table, $column)) {
+                    $missing[] = "{$table}.{$column}";
+                }
+            }
+        }
+
+        return $missing;
+    }
+
+    private static function isAtomTable(string $table): bool
+    {
+        if (in_array($table, self::ATOM_TABLES, true)) {
+            return true;
+        }
+
+        foreach (self::ATOM_TABLE_PREFIXES as $prefix) {
+            if (str_starts_with($table, $prefix)) {
+                return true;
+            }
+        }
+
+        // Left behind by the 2014_10_12_100000 migration's collision rename.
+        return (bool) preg_match('/^password_resets(_\d+)?$/', $table);
+    }
+}

--- a/app/Support/HotelSchemaPreflight.php
+++ b/app/Support/HotelSchemaPreflight.php
@@ -151,7 +151,7 @@ final class HotelSchemaPreflight
      */
     private static function missingSignature(Builder $schema, array $tables): array
     {
-        $closest = null;
+        $closest = [];
         $closestFound = -1;
 
         foreach (self::HOTEL_SIGNATURES as $signature) {
@@ -172,7 +172,7 @@ final class HotelSchemaPreflight
             }
         }
 
-        return $closest ?? [];
+        return $closest;
     }
 
     /**

--- a/config/auth.php
+++ b/config/auth.php
@@ -95,7 +95,7 @@ return [
     'passwords' => [
         'users' => [
             'provider' => 'users',
-            'table' => env('AUTH_PASSWORD_RESET_TOKEN_TABLE', 'password_reset_tokens'),
+            'table' => env('AUTH_PASSWORD_RESET_TOKEN_TABLE', 'website_password_resets'),
             'expire' => 60,
             'throttle' => 60,
         ],

--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -11,6 +11,14 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Emulators ship a `password_resets` table of their own - Polaris keys one
+        // by user_id. Atom's tokens live in `website_password_resets` these days
+        // (2026_08_14_000000), so a foreign table is left exactly as it is instead
+        // of being collided with or reclaimed out from under a running hotel.
+        if (Schema::hasTable('password_resets') && ! $this->isAtomTable()) {
+            return;
+        }
+
         Schema::create('password_resets', function (Blueprint $table) {
             $table->string('email')->index();
             $table->string('token');
@@ -23,6 +31,17 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('password_resets');
+        if ($this->isAtomTable()) {
+            Schema::drop('password_resets');
+        }
+    }
+
+    private function isAtomTable(): bool
+    {
+        return Schema::hasTable('password_resets')
+            && Schema::hasColumns('password_resets', ['email', 'token', 'created_at'])
+            && ! Schema::hasColumn('password_resets', 'user_id')
+            && ! Schema::hasColumn('password_resets', 'expires_at')
+            && ! Schema::hasColumn('password_resets', 'created_ip');
     }
 };

--- a/database/migrations/2023_02_18_000000_rename_password_resets_table.php
+++ b/database/migrations/2023_02_18_000000_rename_password_resets_table.php
@@ -10,6 +10,12 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Only Atom's own table may be renamed - on a database shared with an
+        // emulator, `password_resets` belongs to the emulator (2026_08_14_000000).
+        if (Schema::hasTable('password_reset_tokens') || ! $this->isAtomTable()) {
+            return;
+        }
+
         Schema::rename('password_resets', 'password_reset_tokens');
     }
 
@@ -18,6 +24,17 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::rename('password_reset_tokens', 'password_resets');
+        if (Schema::hasTable('password_reset_tokens') && ! Schema::hasTable('password_resets')) {
+            Schema::rename('password_reset_tokens', 'password_resets');
+        }
+    }
+
+    private function isAtomTable(): bool
+    {
+        return Schema::hasTable('password_resets')
+            && Schema::hasColumns('password_resets', ['email', 'token', 'created_at'])
+            && ! Schema::hasColumn('password_resets', 'user_id')
+            && ! Schema::hasColumn('password_resets', 'expires_at')
+            && ! Schema::hasColumn('password_resets', 'created_ip');
     }
 };

--- a/database/migrations/2023_09_13_130322_update_password_reset_tokens_created_at.php
+++ b/database/migrations/2023_09_13_130322_update_password_reset_tokens_created_at.php
@@ -11,6 +11,12 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Absent on databases where an emulator owned `password_resets` and Atom
+        // therefore never created its own table - see 2026_08_14_000000.
+        if (! Schema::hasTable('password_reset_tokens')) {
+            return;
+        }
+
         Schema::table('password_reset_tokens', function (Blueprint $table) {
             $table->timestamp('created_at')->useCurrent()->change();
         });

--- a/database/migrations/2026_08_14_000000_rename_password_reset_tokens_to_website_password_resets.php
+++ b/database/migrations/2026_08_14_000000_rename_password_reset_tokens_to_website_password_resets.php
@@ -1,0 +1,90 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Tables Atom kept its reset tokens in before the name was namespaced.
+     */
+    private const LEGACY_TABLES = ['password_reset_tokens', 'password_resets'];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $legacy = $this->legacyAtomTable();
+
+        if ($legacy !== null && ! Schema::hasTable('website_password_resets')) {
+            Schema::rename($legacy, 'website_password_resets');
+
+            return;
+        }
+
+        $this->createTable();
+
+        if ($legacy === null) {
+            return;
+        }
+
+        DB::table('website_password_resets')->insertUsing(
+            ['email', 'token', 'created_at'],
+            DB::table($legacy)->select('email', 'token', 'created_at'),
+        );
+
+        Schema::drop($legacy);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasTable('website_password_resets') && ! Schema::hasTable('password_reset_tokens')) {
+            Schema::rename('website_password_resets', 'password_reset_tokens');
+        }
+    }
+
+    private function createTable(): void
+    {
+        if (Schema::hasTable('website_password_resets')) {
+            return;
+        }
+
+        Schema::create('website_password_resets', function (Blueprint $table) {
+            $table->string('email')->index();
+            $table->string('token');
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    private function legacyAtomTable(): ?string
+    {
+        foreach (self::LEGACY_TABLES as $table) {
+            if ($this->isAtomTable($table)) {
+                return $table;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The emulator ships a `password_resets` table of its own, keyed by `user_id` with
+     * an `expires_at` and a `created_ip`. Only a table shaped like the one Atom created
+     * in 2014_10_12_100000 may be taken over - anything else belongs to the emulator and
+     * is left untouched, tokens and all.
+     */
+    private function isAtomTable(string $table): bool
+    {
+        return Schema::hasTable($table)
+            && Schema::hasColumns($table, ['email', 'token', 'created_at'])
+            && ! Schema::hasColumn($table, 'user_id')
+            && ! Schema::hasColumn($table, 'expires_at')
+            && ! Schema::hasColumn($table, 'created_ip');
+    }
+};

--- a/tests/Feature/Installation/HotelSchemaPreflightTest.php
+++ b/tests/Feature/Installation/HotelSchemaPreflightTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use App\Enums\HotelSchemaState;
+use App\Support\HotelSchemaPreflight;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The classifications run against a scratch connection so a database can be
+ * built up table by table. The hotel case is checked against the real test
+ * database, which is the imported Arcturus base.
+ */
+beforeEach(function () {
+    config(['database.connections.preflight' => ['driver' => 'sqlite', 'database' => ':memory:']]);
+
+    $this->scratch = Schema::connection('preflight');
+});
+
+function createHotelSignature(Builder $schema): void
+{
+    $schema->create('users', function (Blueprint $table) {
+        $table->id();
+        $table->string('username');
+        $table->string('password');
+        $table->string('auth_ticket');
+    });
+
+    $schema->create('rooms', function (Blueprint $table) {
+        $table->id();
+        $table->integer('owner_id');
+        $table->string('model');
+    });
+
+    $schema->create('items', function (Blueprint $table) {
+        $table->id();
+        $table->integer('user_id');
+        $table->integer('room_id');
+        $table->integer('item_id');
+    });
+
+    $schema->create('items_base', function (Blueprint $table) {
+        $table->id();
+        $table->string('interaction_type');
+    });
+
+    $schema->create('catalog_pages', function (Blueprint $table) {
+        $table->id();
+        $table->integer('page_layout');
+    });
+
+    $schema->create('emulator_settings', function (Blueprint $table) {
+        $table->string('key');
+        $table->string('value');
+    });
+
+    $schema->create('permissions', function (Blueprint $table) {
+        $table->id();
+        $table->string('rank_name');
+    });
+
+    $schema->create('users_currency', function (Blueprint $table) {
+        $table->integer('user_id');
+        $table->integer('type');
+        $table->integer('amount');
+    });
+}
+
+test('an empty database is safe to import into', function () {
+    $inspection = HotelSchemaPreflight::inspect('preflight');
+
+    expect($inspection->state)->toBe(HotelSchemaState::Fresh)
+        ->and($inspection->state->safeToImport())->toBeTrue();
+});
+
+test('a database holding only atom tables is safe to import into', function () {
+    $this->scratch->create('migrations', fn (Blueprint $table) => $table->id());
+    $this->scratch->create('website_settings', fn (Blueprint $table) => $table->id());
+    $this->scratch->create('user_home_items', fn (Blueprint $table) => $table->id());
+    $this->scratch->create('website_password_resets', fn (Blueprint $table) => $table->id());
+
+    $inspection = HotelSchemaPreflight::inspect('preflight');
+
+    expect($inspection->state)->toBe(HotelSchemaState::AtomOnly)
+        ->and($inspection->state->safeToImport())->toBeTrue();
+});
+
+test('a full hotel schema is recognised and never imported over', function () {
+    createHotelSignature($this->scratch);
+
+    $inspection = HotelSchemaPreflight::inspect('preflight');
+
+    expect($inspection->state)->toBe(HotelSchemaState::Hotel)
+        ->and($inspection->state->safeToImport())->toBeFalse();
+});
+
+test('a hotel keeps being recognised when it carries extra plugin tables', function () {
+    createHotelSignature($this->scratch);
+    $this->scratch->create('plugin_lottery', fn (Blueprint $table) => $table->id());
+
+    expect(HotelSchemaPreflight::inspect('preflight')->state)->toBe(HotelSchemaState::Hotel);
+});
+
+test('a database migrated by an emulator is recognised by its migration history alone', function () {
+    // Polaris records its Flyway history here before the rest of the schema exists.
+    $this->scratch->create('flyway_schema_history', fn (Blueprint $table) => $table->id());
+
+    expect(HotelSchemaPreflight::inspect('preflight')->state)->toBe(HotelSchemaState::Hotel);
+});
+
+test('an entity framework database is recognised by its migration history alone', function () {
+    // Ada creates this before the rest of its schema exists.
+    $this->scratch->create('__EFMigrationsHistory', fn (Blueprint $table) => $table->string('MigrationId'));
+
+    expect(HotelSchemaPreflight::inspect('preflight')->state)->toBe(HotelSchemaState::Hotel);
+});
+
+test('an ada schema is recognised without its migration history', function () {
+    foreach (['players', 'player_data', 'player_avatar_data', 'player_website_data', 'roles', 'badges'] as $table) {
+        $this->scratch->create($table, fn (Blueprint $blueprint) => $blueprint->id());
+    }
+
+    $inspection = HotelSchemaPreflight::inspect('preflight');
+
+    expect($inspection->state)->toBe(HotelSchemaState::Hotel)
+        ->and($inspection->state->safeToImport())->toBeFalse();
+});
+
+test('a half-built hotel is refused instead of being overwritten', function () {
+    // An emulator that died partway through creating its schema.
+    $this->scratch->create('users', function (Blueprint $table) {
+        $table->id();
+        $table->string('username');
+        $table->string('password');
+        $table->string('auth_ticket');
+    });
+    $this->scratch->create('rooms', fn (Blueprint $table) => $table->id());
+
+    $inspection = HotelSchemaPreflight::inspect('preflight');
+
+    expect($inspection->state)->toBe(HotelSchemaState::Unknown)
+        ->and($inspection->state->safeToImport())->toBeFalse()
+        ->and($inspection->unrecognised)->toContain('users', 'rooms')
+        ->and($inspection->missingSignature)->toContain('items', 'emulator_settings');
+});
+
+test('an unrelated database is refused', function () {
+    $this->scratch->create('wp_posts', fn (Blueprint $table) => $table->id());
+    $this->scratch->create('wp_options', fn (Blueprint $table) => $table->id());
+
+    $inspection = HotelSchemaPreflight::inspect('preflight');
+
+    expect($inspection->state)->toBe(HotelSchemaState::Unknown)
+        ->and($inspection->unrecognised)->toEqualCanonicalizing(['wp_posts', 'wp_options']);
+});
+
+test('the installed test database reads as an existing hotel', function () {
+    expect(HotelSchemaPreflight::inspect()->state)->toBe(HotelSchemaState::Hotel);
+});


### PR DESCRIPTION
Atom and the emulator share one schema, and two places in Atom assumed otherwise.

## Password reset tokens move to `website_password_resets`

`password_resets` is a table emulators own — Polaris keys one by `user_id` with an `expires_at` and a `created_ip`. Atom's own migrations created it, renamed it, and (through the collision-aware builder on this branch's base) would reclaim it, which on a live hotel either fails the install or renames the emulator's table out from under it.

- New migration `2026_08_14_000000` takes over the legacy table **only** when its columns match the one Atom created in `2014_10_12_100000` (`email`, `token`, `created_at`, and none of `user_id` / `expires_at` / `created_ip`). If `website_password_resets` already exists it copies the rows across instead. A foreign table is left exactly as it is, tokens and all.
- `2014_10_12_100000`, `2023_02_18_000000` and `2023_09_13_130322` grew the same shape check, so a fresh install against an existing hotel is a no-op rather than a collision.
- `PasswordResetToken` and `config/auth.php` point at the new table.

Polaris' own repair migration adds `user_id`/`created_ip` to a CMS-era `password_resets`, so a hybrid table reads as foreign and Atom starts clean. Tokens live 15 minutes, so nothing durable is lost.

## The installer no longer offers to wipe a hotel

The bundled Arcturus dump opens with `DROP TABLE IF EXISTS` for all 122 tables it ships, and `ensureEmptyDatabase()` would offer to clear any non-empty database — `--fresh` did it without asking.

`HotelSchemaPreflight` classifies the target database as `Fresh`, `AtomOnly`, `Hotel` or `Unknown` before anything is written, mirroring the check Polaris runs before it migrates. A `Hotel` — Arcturus' table signature, Polaris' `flyway_schema_history`, Ada's `__EFMigrationsHistory`, or a spread of Ada's own tables — is now refused outright, `--fresh` included, and the operator is pointed at `--skip-arcturus`. Empty and Atom-only databases keep the existing prompt, which now names the tables nobody claims.

## Testing

`vendor/bin/pest` — 382 passed (1484 assertions), including 10 new preflight cases covering empty, Atom-only, full hotel, hotel + plugin tables, Flyway-history-only, EF-history-only, an Ada schema, a half-built hotel, and an unrelated WordPress database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)