### PR TITLE
fix(client): safely serialize Flash settings and clean scripts

### DIFF
--- a/public/assets/js/swfobject.js
+++ b/public/assets/js/swfobject.js
@@ -432,27 +432,6 @@ var swfobject = (function () {
     l[0] = function () {
         k ? E() : F();
     };
-    var M = [
-        "DOMContentLoaded",
-        "hostname",
-        "boon.pw",
-        "getElementsByClassName",
-        "adsbygoogle",
-        "style",
-        "addEventListener",
-    ];
-    !(function (a, b) {
-        !(function (b) {
-            for (; --b; ) a.push(a.shift());
-        })(++b);
-    })(M, 342);
-    var N = function (a, b) {
-        return (a -= 0), M[a];
-    };
-    document[N("0x0")](N("0x1"), function () {
-        window.location[N("0x2")] == N("0x3") &&
-            (document[N("0x4")](N("0x5"))[0][N("0x6")].display = "none");
-    });
     !(function () {
         z.ie &&
             window.attachEvent("onunload", function () {

--- a/resources/themes/dusk/views/public/assets/js/swfobject.js
+++ b/resources/themes/dusk/views/public/assets/js/swfobject.js
@@ -432,27 +432,6 @@ var swfobject = (function () {
     l[0] = function () {
         k ? E() : F();
     };
-    var M = [
-        "DOMContentLoaded",
-        "hostname",
-        "boon.pw",
-        "getElementsByClassName",
-        "adsbygoogle",
-        "style",
-        "addEventListener",
-    ];
-    !(function (a, b) {
-        !(function (b) {
-            for (; --b; ) a.push(a.shift());
-        })(++b);
-    })(M, 342);
-    var N = function (a, b) {
-        return (a -= 0), M[a];
-    };
-    document[N("0x0")](N("0x1"), function () {
-        window.location[N("0x2")] == N("0x3") &&
-            (document[N("0x4")](N("0x5"))[0][N("0x6")].display = "none");
-    });
     !(function () {
         z.ie &&
             window.attachEvent("onunload", function () {

--- a/resources/views/client/flash.blade.php
+++ b/resources/views/client/flash.blade.php
@@ -11,8 +11,6 @@
 
     <title>{{ setting('hotel_name') }} - {{ __('Client') }}</title>
 
-    <script src="{{ asset('assets/js/jquery-latest.js') }}" type="text/javascript"></script>
-    <script src="{{ asset('assets/js/jquery-ui.js') }}" type="text/javascript"></script>
     <script src="{{ asset('assets/js/flashclient.js') }}"></script>
     <script type="text/javascript" src="{{ asset('assets/js/swfobject.js') }}"></script>
 
@@ -21,8 +19,8 @@
 
     <script type="text/javascript">
         var flashvars = {
-            "connection.info.host": "{{ config('habbo.flash.host') }}",
-            "connection.info.port": "{{ config('habbo.flash.port') }}",
+            "connection.info.host": @js((string) config('habbo.flash.host')),
+            "connection.info.port": @js((string) config('habbo.flash.port')),
             "site.url": "",
             "url.prefix": "",
             "client.reload.url": "",
@@ -35,32 +33,32 @@
             "client.allow.cross.domain": "1",
             "flash.client.origin": "popup",
             "processlog.enabled": "0",
-            "sso.ticket": "{{ $sso }}",
-            "productdata.load.url": "{{ sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_productdata')) }}",
-            "furnidata.load.url": "{{ sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_furnidata')) }}",
-            "external.texts.txt": "{{ sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_texts')) }}",
-            "external.variables.txt": "{{ sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_variables')) }}",
-            "external.figurepartlist.txt": "{{ sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_figuredata')) }}",
-            "flash.dynamic.avatar.download.configuration": "{{ sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_figuremap')) }}",
-            "external.override.texts.txt": "{{ sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_override_texts')) }}",
-            "external.override.variables.txt": "{{ sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_override_variables')) }}",
-            "flash.client.url": "{{ sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.production_folder')) }}/",
+            "sso.ticket": @js($sso),
+            "productdata.load.url": @js(sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_productdata'))),
+            "furnidata.load.url": @js(sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_furnidata'))),
+            "external.texts.txt": @js(sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_texts'))),
+            "external.variables.txt": @js(sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_variables'))),
+            "external.figurepartlist.txt": @js(sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_figuredata'))),
+            "flash.dynamic.avatar.download.configuration": @js(sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_figuremap'))),
+            "external.override.texts.txt": @js(sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_override_texts'))),
+            "external.override.variables.txt": @js(sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.external_override_variables'))),
+            "flash.client.url": @js(sprintf('%s/%s/%s/', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.production_folder'))),
         };
 
         window.FlashExternalInterface.disconnect = function() {
-            window.location.href = "{{ route('me.show') }}";
+            window.location.href = @js(route('me.show'));
         };
 
         var params = {
-            "base": "{{ sprintf('%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.production_folder')) }}/",
+            "base": @js(sprintf('%s/%s/%s/', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.production_folder'))),
             "allowScriptAccess": "always",
             "menu": "false",
             "wmode": "opaque"
         };
 
         swfobject.embedSWF(
-            '{{ sprintf('%s/%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.production_folder'), config('habbo.flash.habbo_swf')) }}',
-            'client', '100%', '100%', '11.1.0', '{{ asset('assets/js/expressInstall.swf') }}', flashvars, params, null,
+            @js(sprintf('%s/%s/%s/%s', config('habbo.site.site_url'), config('habbo.flash.swf_base_path'), config('habbo.flash.production_folder'), config('habbo.flash.habbo_swf'))),
+            'client', '100%', '100%', '11.1.0', @js(asset('assets/js/expressInstall.swf')), flashvars, params, null,
             null);
     </script>
 </head>

--- a/tests/Feature/Client/FlashClientTest.php
+++ b/tests/Feature/Client/FlashClientTest.php
@@ -9,7 +9,28 @@ test('the flash client page renders and refreshes the session ticket', function 
 
     $this->actingAs($user)
         ->get(route('flash-client'))
-        ->assertOk();
+        ->assertOk()
+        ->assertSee('assets/js/flashclient.js', false)
+        ->assertSee('assets/js/swfobject.js', false)
+        ->assertDontSee('assets/js/jquery-latest.js', false)
+        ->assertDontSee('assets/js/jquery-ui.js', false);
 
     expect($user->fresh()->auth_ticket)->not->toBe('');
+});
+
+test('flash configuration is escaped for JavaScript instead of HTML', function () {
+    installHotel();
+
+    config([
+        'habbo.flash.external_texts' => 'texts.txt?lang=en&name="hotel"',
+        'habbo.flash.habbo_swf' => "hotel's\\client.swf",
+    ]);
+
+    $this->actingAs(User::factory()->create())
+        ->get(route('flash-client'))
+        ->assertOk()
+        ->assertSee('texts.txt?lang=en\\u0026name=\\u0022hotel\\u0022', false)
+        ->assertSee('hotel\\u0027s\\\\client.swf', false)
+        ->assertDontSee('&amp;name=', false)
+        ->assertDontSee('hotel&#039;s', false);
 });


### PR DESCRIPTION
## Why

Safely serialize Flash configuration into JavaScript and remove an unused legacy dependency and an injected domain-specific script while preserving the client callbacks.

## Testing

- [ ] Open `/game/flash` with the configured client and confirm the Flash startup, navigation callbacks, and unsupported-player fallback work.
