### PR TITLE
fix(atom): restore article slider initialization

### DIFF
--- a/resources/themes/atom/js/components/AtomSliders.js
+++ b/resources/themes/atom/js/components/AtomSliders.js
@@ -9,7 +9,7 @@ const AtomSliders = {
     },
 
     initArticleSlider() {
-        if (!document.querySelector(".article-slider")) return;
+        if (!document.querySelector(".articles-slider")) return;
 
         new Swiper(".articles-slider", {
             modules: [Autoplay, Pagination],


### PR DESCRIPTION
## Why

Match the Atom article slider’s actual markup so its carousel and pagination initialize after navigation.

## Testing

- [ ] Open `/user/me` with multiple published articles and confirm the article slider and pagination work after navigating away and back.
