### PR TITLE
fix(mail): preserve SMTP TLS configuration on Laravel 13

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,9 @@ MAIL_HOST=mailpit
 MAIL_PORT=1025
 MAIL_USERNAME=null
 MAIL_PASSWORD=null
-MAIL_ENCRYPTION=null
+# smtp negotiates STARTTLS; smtps uses implicit TLS. A null scheme infers it
+# from MAIL_PORT (465 uses smtps). Legacy MAIL_ENCRYPTION=ssl remains supported.
+MAIL_SCHEME=null
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
 

--- a/config/mail.php
+++ b/config/mail.php
@@ -36,9 +36,11 @@ return [
     'mailers' => [
         'smtp' => [
             'transport' => 'smtp',
+            // Laravel uses a scheme; retain older MAIL_ENCRYPTION=ssl setups,
+            // including servers that provide implicit TLS on a custom port.
+            'scheme' => env('MAIL_SCHEME') ?: (env('MAIL_ENCRYPTION') === 'ssl' ? 'smtps' : null),
             'host' => env('MAIL_HOST', 'smtp.mailgun.org'),
             'port' => env('MAIL_PORT', 587),
-            'encryption' => env('MAIL_ENCRYPTION', 'tls'),
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
             'timeout' => null,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
   <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
     <testsuite name="Feature">
       <directory suffix="Test.php">./tests/Feature</directory>
     </testsuite>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
   <testsuites>
-    <testsuite name="Unit">
-      <directory suffix="Test.php">./tests/Unit</directory>
+    <testsuite name="Integration">
+      <directory suffix="Test.php">./tests/Integration</directory>
     </testsuite>
     <testsuite name="Feature">
       <directory suffix="Test.php">./tests/Feature</directory>

--- a/tests/Integration/MailConfigurationTest.php
+++ b/tests/Integration/MailConfigurationTest.php
@@ -1,15 +1,15 @@
 <?php
 
-use Illuminate\Container\Container;
-use Illuminate\Foundation\Application;
 use Illuminate\Mail\MailManager;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
+use Tests\TestCase;
+
+uses(TestCase::class);
 
 it('configures the SMTP transport with the requested encryption', function (?string $scheme, ?string $legacyEncryption, int $port, bool $encrypted) {
     $originalEnvironment = $_ENV;
     $originalServer = $_SERVER;
-    $originalContainer = Container::getInstance();
 
     try {
         foreach ([
@@ -23,9 +23,8 @@ it('configures the SMTP transport with the requested encryption', function (?str
             $_ENV[$key] = $_SERVER[$key] = $value;
         }
 
-        $app = new Application(dirname(__DIR__, 2));
-        $config = require $app->configPath('mail.php');
-        $transport = (new MailManager($app))->createSymfonyTransport($config['mailers']['smtp']);
+        $config = require config_path('mail.php');
+        $transport = app(MailManager::class)->createSymfonyTransport($config['mailers']['smtp']);
 
         expect($transport)->toBeInstanceOf(EsmtpTransport::class)
             ->and($transport->isAutoTls())->toBeTrue()
@@ -35,7 +34,6 @@ it('configures the SMTP transport with the requested encryption', function (?str
     } finally {
         $_ENV = $originalEnvironment;
         $_SERVER = $originalServer;
-        Container::setInstance($originalContainer);
     }
 })->with([
     'explicit SMTPS on a custom port' => ['smtps', null, 2525, true],

--- a/tests/Unit/MailConfigurationTest.php
+++ b/tests/Unit/MailConfigurationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Application;
+use Illuminate\Mail\MailManager;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
+
+it('configures the SMTP transport with the requested encryption', function (?string $scheme, ?string $legacyEncryption, int $port, bool $encrypted) {
+    $originalEnvironment = $_ENV;
+    $originalServer = $_SERVER;
+    $originalContainer = Container::getInstance();
+
+    try {
+        foreach ([
+            'MAIL_SCHEME' => $scheme ?? '(null)',
+            'MAIL_ENCRYPTION' => $legacyEncryption ?? '(null)',
+            'MAIL_HOST' => 'smtp.example.test',
+            'MAIL_PORT' => (string) $port,
+            'MAIL_USERNAME' => '(null)',
+            'MAIL_PASSWORD' => '(null)',
+        ] as $key => $value) {
+            $_ENV[$key] = $_SERVER[$key] = $value;
+        }
+
+        $app = new Application(dirname(__DIR__, 2));
+        $config = require $app->configPath('mail.php');
+        $transport = (new MailManager($app))->createSymfonyTransport($config['mailers']['smtp']);
+
+        expect($transport)->toBeInstanceOf(EsmtpTransport::class)
+            ->and($transport->isAutoTls())->toBeTrue()
+            ->and($transport->getStream())->toBeInstanceOf(SocketStream::class)
+            ->and($transport->getStream()->isTLS())->toBe($encrypted)
+            ->and($transport->getStream()->getPort())->toBe($port);
+    } finally {
+        $_ENV = $originalEnvironment;
+        $_SERVER = $originalServer;
+        Container::setInstance($originalContainer);
+    }
+})->with([
+    'explicit SMTPS on a custom port' => ['smtps', null, 2525, true],
+    'legacy SSL on a custom port' => [null, 'ssl', 2525, true],
+    'empty scheme preserves legacy SSL' => ['', 'ssl', 2525, true],
+    'explicit scheme overrides legacy encryption' => ['smtp', 'ssl', 587, false],
+    'implicit TLS on the standard port' => [null, null, 465, true],
+    'SMTP with automatic STARTTLS' => ['smtp', null, 587, false],
+    'legacy STARTTLS remains supported' => [null, 'tls', 587, false],
+    'local Mailpit without implicit TLS' => [null, null, 1025, false],
+]);


### PR DESCRIPTION
## Why

Honor MAIL_SCHEME while retaining legacy SSL configuration so existing SMTP installations keep their intended transport security on Laravel 13.
