### PR TITLE
fix(shop): validate rewards and recheck gift eligibility

### DIFF
--- a/app/Actions/Shop/FulfillPackage.php
+++ b/app/Actions/Shop/FulfillPackage.php
@@ -66,21 +66,18 @@ final readonly class FulfillPackage
 
         [$currencyName, $amount] = explode(':', $item->type_value, 2);
         $currency = CurrencyTypes::fromCurrencyName($currencyName);
+        $amount = $this->positiveInteger($item, $amount);
 
-        if ($currency === null || (int) $amount <= 0) {
+        if ($currency === null || $amount > intdiv(PHP_INT_MAX, $quantity)) {
             throw self::misconfigured($item);
         }
 
-        $this->currencies->give($user, $currency, (int) $amount * $quantity);
+        $this->currencies->give($user, $currency, $amount * $quantity);
     }
 
     private function giveFurniture(User $user, WebsiteShopItem $item, int $quantity): void
     {
-        $baseItemId = (int) $item->type_value;
-
-        if ($baseItemId <= 0) {
-            throw self::misconfigured($item);
-        }
+        $baseItemId = $this->positiveInteger($item, $item->type_value);
 
         $this->furniture->grant($user, $baseItemId, $quantity);
     }
@@ -100,13 +97,20 @@ final readonly class FulfillPackage
 
     private function giveRank(User $user, WebsiteShopItem $item): void
     {
-        $rank = (int) $item->type_value;
+        $rank = $this->positiveInteger($item, $item->type_value);
 
-        if ($rank <= 0) {
+        $user->forceFill(['rank' => $rank])->save();
+    }
+
+    private function positiveInteger(WebsiteShopItem $item, string $value): int
+    {
+        $integer = filter_var(ltrim($value, '0'), FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+
+        if (! ctype_digit($value) || $integer === false) {
             throw self::misconfigured($item);
         }
 
-        $user->forceFill(['rank' => $rank])->save();
+        return $integer;
     }
 
     private static function misconfigured(WebsiteShopItem $item): ShopPurchaseException

--- a/app/Actions/Shop/PurchaseShopPackage.php
+++ b/app/Actions/Shop/PurchaseShopPackage.php
@@ -63,6 +63,10 @@ final readonly class PurchaseShopPackage
 
     private function ensurePackageEligibility(User $recipient, WebsiteShopPackage $package, User $buyer): void
     {
+        if (! $recipient->is($buyer) && ! $package->is_giftable) {
+            throw new ShopPurchaseException(__('This package is not giftable'));
+        }
+
         if (! $package->isAvailable()) {
             throw new ShopPurchaseException(__('This package is no longer available'));
         }
@@ -152,7 +156,7 @@ final readonly class PurchaseShopPackage
                 'website_shop_package_id' => $lockedPackage->id,
                 'gifted_to' => $lockedRecipient->is($lockedBuyer) ? null : $lockedRecipient->id,
             ]);
-        });
+        }, attempts: 3);
     }
 
     private function ensureWithinPurchaseLimit(User $buyer, WebsiteShopPackage $package): void

--- a/tests/Feature/Shop/ShopPackageTest.php
+++ b/tests/Feature/Shop/ShopPackageTest.php
@@ -4,7 +4,10 @@ use App\Actions\Shop\PurchaseShopPackage;
 use App\Data\RconResponse;
 use App\Emulator\Contracts\CurrencyRepository;
 use App\Enums\CurrencyTypes;
+use App\Exceptions\ShopPurchaseException;
 use App\Models\Shop\WebsiteShopCategory;
+use App\Models\Shop\WebsiteShopItem;
+use App\Models\Shop\WebsiteShopPackage;
 use App\Models\Shop\WebsiteShopPurchase;
 use App\Models\User;
 use Database\Seeders\WebsiteShopSeeder;
@@ -146,6 +149,57 @@ test('a gifted package delivers to the recipient and records the gift', function
         ->and((int) $recipient->refresh()->credits)->toBe($recipientCredits + 200)
         ->and(WebsiteShopPurchase::where('user_id', $buyer->id)->where('gifted_to', $recipient->id)->count())->toBe(1);
 });
+
+test('a package that stops being giftable cannot be delivered from a stale model', function () {
+    installHotel();
+
+    $buyer = User::factory()->create(['website_balance' => 10000]);
+    $recipient = User::factory()->create();
+    $package = makePackage(['is_giftable' => true, 'stock' => 1]);
+    $recipientCredits = (int) $recipient->credits;
+
+    WebsiteShopPackage::whereKey($package->id)->update(['is_giftable' => false]);
+
+    expect(fn () => app(PurchaseShopPackage::class)->execute($buyer, $package, $recipient->username))
+        ->toThrow(ShopPurchaseException::class, 'This package is not giftable');
+
+    expect((int) $buyer->refresh()->website_balance)->toBe(10000)
+        ->and((int) $recipient->refresh()->credits)->toBe($recipientCredits)
+        ->and($package->refresh()->stock)->toBe(1)
+        ->and(WebsiteShopPurchase::count())->toBe(0);
+});
+
+test('invalid item numbers reject the purchase and roll back earlier rewards', function (string $type, string $value, int $quantity) {
+    installHotel();
+
+    $buyer = User::factory()->create(['website_balance' => 10000, 'rank' => 1]);
+    $package = makePackage(['stock' => 1]);
+    $credits = (int) $buyer->credits;
+    $rank = (int) $buyer->rank;
+    $item = WebsiteShopItem::create([
+        'name' => 'Misconfigured reward',
+        'type' => $type,
+        'type_value' => $value,
+        'is_active' => true,
+    ]);
+    $package->items()->attach($item->id, ['quantity' => $quantity]);
+
+    $this->actingAs($buyer)
+        ->post(route('shop.buy-package', $package))
+        ->assertSessionHasErrors('message');
+
+    expect((int) $buyer->refresh()->website_balance)->toBe(10000)
+        ->and((int) $buyer->credits)->toBe($credits)
+        ->and((int) $buyer->rank)->toBe($rank)
+        ->and($package->refresh()->stock)->toBe(1)
+        ->and(WebsiteShopPurchase::count())->toBe(0);
+})->with([
+    'currency suffix' => ['currency', 'credits:50bad', 1],
+    'fractional currency' => ['currency', 'credits:50.5', 1],
+    'furniture suffix' => ['furniture', '230bad', 1],
+    'rank suffix' => ['rank', '5bad', 1],
+    'currency multiplication overflow' => ['currency', 'credits:' . PHP_INT_MAX, 2],
+]);
 
 test('an online recipient is disconnected before atomic delivery', function () {
     installHotel();


### PR DESCRIPTION
## Why

Reject invalid or overflowing package rewards and recheck gift eligibility under the purchase lock so failed purchases leave balances and inventory unchanged.
