### PR TITLE
fix(catalog): prevent cyclic page hierarchies

### DIFF
--- a/app/Services/Catalog/CatalogReorderService.php
+++ b/app/Services/Catalog/CatalogReorderService.php
@@ -5,6 +5,7 @@ namespace App\Services\Catalog;
 use App\Models\Game\Furniture\CatalogItem;
 use App\Models\Game\Furniture\CatalogPage;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 
 /**
  * Order numbers are written as (i+1)*10 so future drops have gaps to slot into.
@@ -35,12 +36,33 @@ class CatalogReorderService
      */
     public function movePage(int $pageId, int $newParentId, int $insertAtIndex): void
     {
-        $page = CatalogPage::find($pageId);
-        if (! $page) {
-            return;
-        }
+        DB::transaction(function () use ($pageId, $newParentId, $insertAtIndex) {
+            // Serialize hierarchy changes: two individually valid moves must
+            // not combine into a cycle after reading the same old parents.
+            $pages = CatalogPage::query()->orderBy('id')->lockForUpdate()
+                ->get(['id', 'parent_id', 'order_num'])->keyBy('id');
+            $page = $pages->get($pageId);
 
-        DB::transaction(function () use ($page, $newParentId, $insertAtIndex) {
+            if (! $page) {
+                return;
+            }
+
+            $visited = [$pageId => true];
+            $parentId = $newParentId;
+
+            while ($parentId !== -1) {
+                $parent = $pages->get($parentId);
+
+                if ($parent === null || isset($visited[$parentId])) {
+                    throw ValidationException::withMessages([
+                        'parent_id' => __('Choose an existing catalog parent outside this page and its descendants.'),
+                    ]);
+                }
+
+                $visited[$parentId] = true;
+                $parentId = $parent->parent_id;
+            }
+
             $siblings = CatalogPage::query()
                 ->where('parent_id', $newParentId)
                 ->where('id', '!=', $page->id)

--- a/app/Services/Catalog/CatalogTreeService.php
+++ b/app/Services/Catalog/CatalogTreeService.php
@@ -28,9 +28,11 @@ class CatalogTreeService
 
         $byId = CatalogPage::query()->get()->keyBy('id');
         $chain = [];
+        $visited = [];
         $current = $byId[$page->id] ?? null;
 
-        while ($current) {
+        while ($current && ! isset($visited[$current->id])) {
+            $visited[$current->id] = true;
             array_unshift($chain, $current);
             $current = $current->parent_id > 0 ? ($byId[$current->parent_id] ?? null) : null;
         }
@@ -50,7 +52,7 @@ class CatalogTreeService
 
         foreach ($hitIds as $id) {
             $cursor = $byId[$id] ?? null;
-            while ($cursor) {
+            while ($cursor && ! isset($reveal[$cursor->id])) {
                 $reveal[$cursor->id] = $cursor->id;
                 $cursor = $cursor->parent_id > 0 ? ($byId[$cursor->parent_id] ?? null) : null;
             }

--- a/tests/Feature/Services/CatalogHierarchyTest.php
+++ b/tests/Feature/Services/CatalogHierarchyTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Models\Game\Furniture\CatalogPage;
+use App\Services\Catalog\CatalogReorderService;
+use App\Services\Catalog\CatalogTreeService;
+use Illuminate\Validation\ValidationException;
+
+function hierarchyPage(string $caption, int $parentId = -1, int $order = 10): CatalogPage
+{
+    return CatalogPage::create([
+        'caption' => $caption,
+        'caption_save' => $caption,
+        'parent_id' => $parentId,
+        'order_num' => $order,
+    ]);
+}
+
+test('a catalog page cannot move beneath itself or a descendant', function (bool $self) {
+    $parent = hierarchyPage('Parent');
+    $child = hierarchyPage('Child', $parent->id);
+    $destination = $self ? $parent : $child;
+
+    expect(fn () => app(CatalogReorderService::class)->movePage($parent->id, $destination->id, 0))
+        ->toThrow(ValidationException::class);
+
+    expect($parent->refresh()->parent_id)->toBe(-1)
+        ->and($child->refresh()->parent_id)->toBe($parent->id);
+})->with([true, false]);
+
+test('a catalog page cannot move into a missing parent', function () {
+    $page = hierarchyPage('Page');
+
+    expect(fn () => app(CatalogReorderService::class)->movePage($page->id, 999999999, 0))
+        ->toThrow(ValidationException::class);
+
+    expect($page->refresh()->parent_id)->toBe(-1);
+});
+
+test('valid catalog moves preserve sibling ordering and root moves', function () {
+    $parent = hierarchyPage('Parent');
+    $first = hierarchyPage('First', $parent->id);
+    $last = hierarchyPage('Last', $parent->id, 20);
+    $moved = hierarchyPage('Moved');
+    $reorder = app(CatalogReorderService::class);
+
+    $reorder->movePage($moved->id, $parent->id, 1);
+
+    expect(CatalogPage::where('parent_id', $parent->id)->orderBy('order_num')->pluck('id')->all())
+        ->toBe([$first->id, $moved->id, $last->id]);
+
+    $reorder->movePage($moved->id, -1, 0);
+
+    expect($moved->refresh()->parent_id)->toBe(-1)
+        ->and(app(CatalogTreeService::class)->breadcrumb($last))->toHaveCount(2)
+        ->and(app(CatalogTreeService::class)->expandToReveal(collect([$last->id, $first->id])))
+        ->toEqualCanonicalizing([$parent->id, $last->id, $first->id]);
+});
+
+test('existing catalog cycles cannot trap breadcrumbs or ancestor expansion', function () {
+    $first = hierarchyPage('First');
+    $second = hierarchyPage('Second', $first->id);
+    $first->update(['parent_id' => $second->id]);
+    $tree = app(CatalogTreeService::class);
+
+    expect(array_map(fn (CatalogPage $page) => $page->id, $tree->breadcrumb($first)))
+        ->toBe([$second->id, $first->id])
+        ->and($tree->expandToReveal(collect([$first->id, $second->id])))
+        ->toEqualCanonicalizing([$first->id, $second->id]);
+});
+
+test('a catalog page cannot join an existing cycle but can be moved out of one', function () {
+    $first = hierarchyPage('First');
+    $second = hierarchyPage('Second', $first->id);
+    $first->update(['parent_id' => $second->id]);
+    $page = hierarchyPage('Page');
+    $reorder = app(CatalogReorderService::class);
+
+    expect(fn () => $reorder->movePage($page->id, $first->id, 0))
+        ->toThrow(ValidationException::class);
+
+    $reorder->movePage($first->id, -1, 0);
+
+    expect($first->refresh()->parent_id)->toBe(-1)
+        ->and(app(CatalogTreeService::class)->breadcrumb($second))->toHaveCount(2);
+});


### PR DESCRIPTION
## Why

Reject catalog moves that create invalid parent relationships and bound traversal of existing malformed trees so catalog management remains usable.
