### PR TITLE
fix(import): reject invalid badges without partial writes

### DIFF
--- a/app/Console/Commands/ImportBadgeData.php
+++ b/app/Console/Commands/ImportBadgeData.php
@@ -6,7 +6,9 @@ use App\Models\WebsiteBadge;
 use App\Services\SettingsService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use RuntimeException;
 use Throwable;
 
 class ImportBadgeData extends Command
@@ -71,7 +73,13 @@ class ImportBadgeData extends Command
 
     private function processBadgeData(string $jsonPath): void
     {
-        $jsonData = File::json($jsonPath);
+        $document = json_decode(File::get($jsonPath), flags: JSON_THROW_ON_ERROR);
+
+        if (! is_object($document)) {
+            throw new RuntimeException('Nitro external texts must contain a JSON object.');
+        }
+
+        $jsonData = get_object_vars($document);
 
         // Extract badge names and descriptions
         $badgeNames = Collection::make($jsonData)
@@ -89,15 +97,18 @@ class ImportBadgeData extends Command
             'badge_description' => $badgeDescriptions->get($key, 'No description available'),
         ])->values();
 
-        // Upsert the combined data in chunks
-        $badgeData->chunk(self::CHUNK_SIZE)->each(function ($chunk) {
-            WebsiteBadge::upsert(
-                $chunk->toArray(),
-                ['badge_key'],
-                ['badge_name', 'badge_description'],
-            );
+        // A later chunk can fail after earlier definitions were updated.
+        // Keep the previous import intact unless every chunk succeeds.
+        DB::transaction(function () use ($badgeData): void {
+            $badgeData->chunk(self::CHUNK_SIZE)->each(function ($chunk) {
+                WebsiteBadge::upsert(
+                    $chunk->toArray(),
+                    ['badge_key'],
+                    ['badge_name', 'badge_description'],
+                );
 
-            $this->info('Processed ' . $chunk->count() . ' badges.');
+                $this->info('Processed ' . $chunk->count() . ' badges.');
+            });
         });
     }
 }

--- a/tests/Feature/Services/BadgeImportTest.php
+++ b/tests/Feature/Services/BadgeImportTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Models\WebsiteBadge;
+use Illuminate\Support\Facades\File;
+
+beforeEach(function () {
+    $this->badgeImportPath = tempnam(sys_get_temp_dir(), 'atom-badge-import-');
+    setSetting('nitro_external_texts_file', $this->badgeImportPath);
+});
+
+afterEach(function () {
+    File::delete($this->badgeImportPath);
+});
+
+test('badge imports reject malformed JSON and non-object documents', function (string $contents) {
+    File::put($this->badgeImportPath, $contents);
+
+    $this->artisan('import:badge-data')->assertFailed();
+
+    expect(WebsiteBadge::count())->toBe(0);
+})->with(['{"badge_name_TEST":', 'null', '42', '["badge_name_TEST"]']);
+
+test('badge imports update names and descriptions without duplicating definitions', function () {
+    File::put($this->badgeImportPath, json_encode([
+        'badge_name_TEST' => 'First name',
+        'badge_desc_TEST' => 'First description',
+        'unrelated_setting' => ['nested' => true],
+    ], JSON_THROW_ON_ERROR));
+
+    $this->artisan('import:badge-data')->assertSuccessful();
+
+    File::put($this->badgeImportPath, json_encode([
+        'badge_name_TEST' => 'Updated name',
+        'badge_desc_TEST' => 'Updated description',
+    ], JSON_THROW_ON_ERROR));
+
+    $this->artisan('import:badge-data')->assertSuccessful();
+
+    expect(WebsiteBadge::count())->toBe(1)
+        ->and(WebsiteBadge::first()->only(['badge_key', 'badge_name', 'badge_description']))
+        ->toBe([
+            'badge_key' => 'TEST',
+            'badge_name' => 'Updated name',
+            'badge_description' => 'Updated description',
+        ]);
+});
+
+test('a failure in a later badge import chunk preserves all existing definitions', function () {
+    WebsiteBadge::create([
+        'badge_key' => 'TEST0',
+        'badge_name' => 'Original',
+        'badge_description' => 'Original description',
+    ]);
+    $data = [];
+
+    for ($index = 0; $index < 100; $index++) {
+        $data['badge_name_TEST' . $index] = 'Updated name';
+    }
+
+    $data['badge_name_INVALID'] = str_repeat('x', 256);
+    File::put($this->badgeImportPath, json_encode($data, JSON_THROW_ON_ERROR));
+
+    $this->artisan('import:badge-data')->assertFailed();
+
+    expect(WebsiteBadge::count())->toBe(1)
+        ->and(WebsiteBadge::first()->badge_name)->toBe('Original');
+});


### PR DESCRIPTION
## Why

Validate badge imports before persisting them and roll back the whole import on failure so malformed data cannot leave partial updates.
