### PR TITLE
fix(install): preserve literal database credentials in dotenv

### DIFF
--- a/app/Console/Commands/AtomInstallCommand.php
+++ b/app/Console/Commands/AtomInstallCommand.php
@@ -316,13 +316,20 @@ class AtomInstallCommand extends Command
 
     private function replaceEnvValue(string $contents, string $key, string $value, string $path): string
     {
-        $line = str_contains($value, ' ') ? sprintf('%s="%s"', $key, $value) : sprintf('%s=%s', $key, $value);
+        $escaped = strtr($value, [
+            '\\' => '\\\\',
+            '"' => '\\"',
+            '$' => '\\$',
+            "\r" => '\\r',
+            "\n" => '\\n',
+        ]);
+        $line = sprintf('%s="%s"', $key, $escaped);
 
         if (preg_match("/^{$key}=.*$/m", $contents) !== 1) {
             return $contents . PHP_EOL . $line;
         }
 
-        $updated = preg_replace("/^{$key}=.*$/m", $line, $contents);
+        $updated = preg_replace_callback("/^{$key}=.*$/m", fn (): string => $line, $contents);
 
         if (! is_string($updated)) {
             throw new \RuntimeException("Unable to update {$key} in environment file: {$path}");

--- a/tests/Feature/Installation/InstallerEnvironmentTest.php
+++ b/tests/Feature/Installation/InstallerEnvironmentTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Console\Commands\AtomInstallCommand;
+use Dotenv\Dotenv;
+
+test('installer database credentials round trip through dotenv without interpolation', function (string $password, bool $replaceExisting) {
+    $contents = "EXISTING_VALUE=expanded\nAPP_DEBUG=false\n";
+
+    if ($replaceExisting) {
+        $contents .= "DB_PASSWORD=old-password\n";
+    }
+
+    $replace = new ReflectionMethod(AtomInstallCommand::class, 'replaceEnvValue');
+    $updated = $replace->invoke(new AtomInstallCommand, $contents, 'DB_PASSWORD', $password, '/test/.env');
+    $parsed = Dotenv::parse($updated);
+
+    expect($parsed['DB_PASSWORD'])->toBe($password)
+        ->and($parsed['APP_DEBUG'])->toBe('false')
+        ->and($parsed['EXISTING_VALUE'])->toBe('expanded')
+        ->and($parsed)->toHaveCount(3);
+})->with([
+    'backreference' => ['password$1value'],
+    'dotenv expansion' => ['password${EXISTING_VALUE}'],
+    'comment character' => ['password#value'],
+    'quotes and spaces' => ['password "quoted" value'],
+    'backslashes' => ['password\\value\\'],
+    'literal newline escape' => ['password\\nvalue'],
+    'line injection' => ["password\nAPP_DEBUG=true"],
+    'carriage return' => ["password\rvalue"],
+    'empty' => [''],
+])->with([true, false]);


### PR DESCRIPTION
## Why

Escape installer credentials correctly in dotenv so quotes, dollar signs, backslashes, and line breaks retain their intended values.
