### PR TITLE
fix(articles): share interaction limits across HTTP and Livewire

### DIFF
--- a/app/Services/Articles/CommentService.php
+++ b/app/Services/Articles/CommentService.php
@@ -11,8 +11,12 @@ use Illuminate\Validation\ValidationException;
 
 class CommentService
 {
+    public function __construct(private readonly InteractionRateLimiter $rateLimiter) {}
+
     public function store(User $user, string $comment, WebsiteArticle $article): WebsiteArticleComment
     {
+        $this->rateLimiter->hit($user, 'comments', 10);
+
         return DB::transaction(function () use ($user, $comment, $article): WebsiteArticleComment {
             $article = WebsiteArticle::whereKey($article->id)->lockForUpdate()->firstOrFail();
 

--- a/app/Services/Articles/InteractionRateLimiter.php
+++ b/app/Services/Articles/InteractionRateLimiter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\Articles;
+
+use App\Models\User;
+use Illuminate\Support\Facades\RateLimiter;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+
+class InteractionRateLimiter
+{
+    public function hit(User $user, string $interaction, int $maximumAttempts): void
+    {
+        $key = "article-interactions:{$interaction}:{$user->id}";
+
+        if (RateLimiter::increment($key, decaySeconds: 60) > $maximumAttempts) {
+            throw new TooManyRequestsHttpException(RateLimiter::availableIn($key), 'Too Many Attempts.');
+        }
+    }
+}

--- a/app/Services/Articles/ReactionService.php
+++ b/app/Services/Articles/ReactionService.php
@@ -10,9 +10,13 @@ use Illuminate\Support\Collection;
 
 class ReactionService
 {
+    public function __construct(private readonly InteractionRateLimiter $rateLimiter) {}
+
     /** @return array{success: bool, added: bool, username: string} */
     public function toggleReaction(WebsiteArticle $article, User $user, string $reaction): array
     {
+        $this->rateLimiter->hit($user, 'reactions', 30);
+
         $record = $this->toggle($article, $user, $reaction);
 
         return [

--- a/tests/Feature/Community/ArticleRateLimitTest.php
+++ b/tests/Feature/Community/ArticleRateLimitTest.php
@@ -74,11 +74,11 @@ test('reaction limits are shared between HTTP and Livewire and recover after a m
     expect($this->article->reactions()->count())->toBe(0);
 
     $otherReader = User::factory()->create();
-    $this->actingAs($otherReader)
+    $this->flushSession()->actingAs($otherReader)
         ->postJson(route('article.toggle-reaction', $this->article->slug), ['reaction' => 'like'])
         ->assertOk();
 
-    $this->actingAs($this->reader);
+    $this->flushSession()->actingAs($this->reader);
     $this->travel(61)->seconds();
 
     Livewire::test(ArticleReactions::class, ['article' => $this->article])

--- a/tests/Feature/Community/ArticleRateLimitTest.php
+++ b/tests/Feature/Community/ArticleRateLimitTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use App\Livewire\ArticleComments;
+use App\Livewire\ArticleReactions;
+use App\Models\Articles\WebsiteArticle;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    installHotel();
+    setSetting('max_comment_per_article', '50');
+
+    $this->reader = User::factory()->create();
+    $this->article = WebsiteArticle::create([
+        'user_id' => $this->reader->id,
+        'title' => 'Shared article interaction limits',
+        'short_story' => 'The same limits apply to all clients.',
+        'full_story' => '<p>The same limits apply to all clients.</p>',
+        'image' => 'articles/limits.png',
+        'can_comment' => true,
+    ]);
+    $this->actingAs($this->reader);
+});
+
+test('comment limits are shared between HTTP and Livewire and recover after a minute', function () {
+    foreach (range(1, 9) as $attempt) {
+        $this->post(route('article.comment.store', $this->article->slug), ['comment' => "HTTP comment {$attempt}"])
+            ->assertSessionHas('success');
+    }
+
+    Livewire::test(ArticleComments::class, ['article' => $this->article])
+        ->set('comment', 'The tenth comment uses Livewire.')
+        ->call('postComment')
+        ->assertHasNoErrors();
+
+    $this->postJson(route('article.comment.store', $this->article->slug), ['comment' => 'Too many comments.'])
+        ->assertTooManyRequests()
+        ->assertHeader('Retry-After');
+
+    Livewire::test(ArticleComments::class, ['article' => $this->article])
+        ->set('comment', 'Livewire also reached the limit.')
+        ->call('postComment')
+        ->assertStatus(429);
+
+    expect($this->article->comments()->count())->toBe(10);
+
+    $this->travel(61)->seconds();
+
+    Livewire::test(ArticleComments::class, ['article' => $this->article])
+        ->set('comment', 'Allowed after the limit expires.')
+        ->call('postComment')
+        ->assertHasNoErrors();
+
+    expect($this->article->comments()->count())->toBe(11);
+});
+
+test('reaction limits are shared between HTTP and Livewire and recover after a minute', function () {
+    foreach (range(1, 29) as $attempt) {
+        $this->postJson(route('article.toggle-reaction', $this->article->slug), ['reaction' => 'like'])->assertOk();
+    }
+
+    Livewire::test(ArticleReactions::class, ['article' => $this->article])
+        ->call('toggleReaction', 'like')
+        ->assertHasNoErrors();
+
+    $this->postJson(route('article.toggle-reaction', $this->article->slug), ['reaction' => 'like'])
+        ->assertTooManyRequests()
+        ->assertHeader('Retry-After');
+
+    Livewire::test(ArticleReactions::class, ['article' => $this->article])
+        ->call('toggleReaction', 'like')
+        ->assertStatus(429);
+
+    expect($this->article->reactions()->count())->toBe(0);
+
+    $otherReader = User::factory()->create();
+    $this->actingAs($otherReader)
+        ->postJson(route('article.toggle-reaction', $this->article->slug), ['reaction' => 'like'])
+        ->assertOk();
+
+    $this->actingAs($this->reader);
+    $this->travel(61)->seconds();
+
+    Livewire::test(ArticleReactions::class, ['article' => $this->article])
+        ->call('toggleReaction', 'like')
+        ->assertHasNoErrors();
+
+    expect($this->article->reactions()->where('user_id', $this->reader->id)->count())->toBe(1);
+});


### PR DESCRIPTION
## Why

Apply the same per-user comment and reaction budgets through HTTP and Livewire while retaining existing HTTP throttles and response headers.
