### PR TITLE
fix(auth): normalize login rate-limit identities

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Laravel\Fortify\Actions\AttemptToAuthenticate;
 use Laravel\Fortify\Actions\EnsureLoginIsNotThrottled;
 use Laravel\Fortify\Actions\PrepareAuthenticatedSession;
@@ -35,7 +36,14 @@ class FortifyServiceProvider extends ServiceProvider
 
     private function configureRateLimiting(): void
     {
-        RateLimiter::for('login', fn (Request $request) => Limit::perMinute(5)->by($request->input('username') . $request->ip()));
+        RateLimiter::for('login', function (Request $request): Limit {
+            $username = $request->input('username');
+            $identity = is_string($username)
+                ? 'username:' . Str::transliterate(Str::lower($username))
+                : 'invalid-username';
+
+            return Limit::perMinute(5)->by($identity . '|' . $request->ip());
+        });
         RateLimiter::for('two-factor', fn (Request $request) => Limit::perMinute(5)->by($request->session()->get('login.id')));
         RateLimiter::for('two-factor-settings', fn (Request $request) => Limit::perMinute(6)->by(
             ($request->user()?->getAuthIdentifier() ?? 'guest') . '|' . $request->ip(),

--- a/tests/Feature/Auth/LoginRateLimitTest.php
+++ b/tests/Feature/Auth/LoginRateLimitTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\User;
+
+test('login rate limits cannot be bypassed by changing username case', function () {
+    installHotel();
+    $user = User::factory()->create(['username' => 'CaseSensitiveUser']);
+
+    foreach (range(1, 5) as $attempt) {
+        $this->post(route('login.store'), [
+            'username' => strtolower($user->username),
+            'password' => 'wrong-password',
+        ])->assertSessionHasErrors('username');
+    }
+
+    $this->post(route('login.store'), [
+        'username' => strtoupper($user->username),
+        'password' => 'password',
+    ])->assertTooManyRequests();
+
+    $this->assertGuest();
+    $this->travel(61)->seconds();
+
+    $this->post(route('login.store'), [
+        'username' => strtoupper($user->username),
+        'password' => 'password',
+    ])->assertRedirect(route('me.show'));
+
+    $this->assertAuthenticatedAs($user);
+});
+
+test('malformed login usernames fail validation without crashing the rate limiter', function () {
+    installHotel();
+
+    $this->postJson(route('login.store'), [
+        'username' => ['unexpected' => 'value'],
+        'password' => 'password',
+    ])->assertUnprocessable()->assertJsonValidationErrors('username');
+
+    $this->assertGuest();
+});


### PR DESCRIPTION
## Why

Use a consistent login rate-limit key for username case variants and reject malformed usernames through normal validation.
