### PR TITLE
fix(badges): serialize grants across both emulator schemas

### DIFF
--- a/app/Emulator/Drivers/Ada/AdaBadgeRepository.php
+++ b/app/Emulator/Drivers/Ada/AdaBadgeRepository.php
@@ -6,10 +6,10 @@ use App\Emulator\Contracts\BadgeRepository;
 use App\Emulator\Data\OwnedBadge;
 use App\Models\Ada\AdaPlayerBadge;
 use App\Models\User;
+use App\Services\Badge\BadgeGrantMutex;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -21,11 +21,7 @@ use Illuminate\Support\Facades\DB;
  */
 class AdaBadgeRepository implements BadgeRepository
 {
-    /** How long a grant may hold its lock before it is considered abandoned. */
-    private const LOCK_SECONDS = 10;
-
-    /** How long a competing grant waits for its turn before giving up. */
-    private const LOCK_WAIT_SECONDS = 5;
+    public function __construct(private readonly BadgeGrantMutex $mutex = new BadgeGrantMutex) {}
 
     /** @return HasMany<AdaPlayerBadge, User> */
     public function relation(User $user): HasMany
@@ -40,36 +36,19 @@ class AdaBadgeRepository implements BadgeRepository
 
     public function grant(User $user, string $badge): void
     {
-        // Resolving the definition and claiming ownership are both
-        // read-then-insert, and Ada constrains neither table, so a transaction
-        // alone lets two concurrent grants both see absence and both write.
-        // Serialising on the pair keeps Atom's own grants single-file.
-        Cache::lock($this->lockFor($user, $badge), self::LOCK_SECONDS)->block(
-            self::LOCK_WAIT_SECONDS,
-            fn () => DB::transaction(function () use ($user, $badge): void {
-                $badgeId = $this->badgeId($badge);
+        // The code lock also serializes definitions shared by different
+        // players and remains held through an outer purchase transaction.
+        $this->mutex->run($badge, function () use ($user, $badge): void {
+            if ($this->badges($user)->where('badges.code', $badge)->lockForUpdate()->exists()) {
+                return;
+            }
 
-                $owned = DB::table('player_badges')
-                    ->where('player_id', $user->id)
-                    ->where('badge_id', $badgeId)
-                    ->exists();
-
-                if ($owned) {
-                    return;
-                }
-
-                DB::table('player_badges')->insert([
-                    'player_id' => $user->id,
-                    'badge_id' => $badgeId,
-                    'slot' => 0,
-                ]);
-            }),
-        );
-    }
-
-    private function lockFor(User $user, string $badge): string
-    {
-        return sprintf('ada-badge-grant:%d:%s', $user->id, sha1($badge));
+            DB::table('player_badges')->insert([
+                'player_id' => $user->id,
+                'badge_id' => $this->badgeId($badge),
+                'slot' => 0,
+            ]);
+        });
     }
 
     public function revoke(User $user, string $badge): void
@@ -98,7 +77,7 @@ class AdaBadgeRepository implements BadgeRepository
      */
     private function badgeId(string $code): int
     {
-        $existing = DB::table('badges')->where('code', $code)->orderBy('id')->value('id');
+        $existing = DB::table('badges')->where('code', $code)->orderBy('id')->lockForUpdate()->value('id');
 
         return (int) ($existing ?? DB::table('badges')->insertGetId(['code' => $code]));
     }

--- a/app/Emulator/Drivers/Arcturus/ArcturusBadgeRepository.php
+++ b/app/Emulator/Drivers/Arcturus/ArcturusBadgeRepository.php
@@ -6,6 +6,7 @@ use App\Emulator\Contracts\BadgeRepository;
 use App\Emulator\Data\OwnedBadge;
 use App\Models\Game\Player\UserBadge;
 use App\Models\User;
+use App\Services\Badge\BadgeGrantMutex;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Pagination\LengthAwarePaginator;
 
@@ -14,6 +15,8 @@ use Illuminate\Pagination\LengthAwarePaginator;
  */
 class ArcturusBadgeRepository implements BadgeRepository
 {
+    public function __construct(private readonly BadgeGrantMutex $mutex = new BadgeGrantMutex) {}
+
     /** @return HasMany<UserBadge, User> */
     public function relation(User $user): HasMany
     {
@@ -27,16 +30,18 @@ class ArcturusBadgeRepository implements BadgeRepository
 
     public function grant(User $user, string $badge): void
     {
-        // Neither emulator constrains ownership in the database, so the
-        // driver guarantees idempotency itself.
-        if ($this->relation($user)->where('badge_code', $badge)->exists()) {
-            return;
-        }
+        $this->mutex->run($badge, function () use ($user, $badge): void {
+            // Use a current read; MariaDB may instead require the outer
+            // transaction to retry when its earlier snapshot is stale.
+            if ($this->relation($user)->where('badge_code', $badge)->lockForUpdate()->exists()) {
+                return;
+            }
 
-        $this->relation($user)->create([
-            'slot_id' => 0,
-            'badge_code' => $badge,
-        ]);
+            $this->relation($user)->create([
+                'slot_id' => 0,
+                'badge_code' => $badge,
+            ]);
+        });
     }
 
     public function revoke(User $user, string $badge): void

--- a/app/Filament/Resources/User/Users/RelationManagers/BadgesRelationManager.php
+++ b/app/Filament/Resources/User/Users/RelationManagers/BadgesRelationManager.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\User\Users\RelationManagers;
 
 use App\Contracts\Rcon;
+use App\Emulator\Contracts\BadgeRepository;
 use App\Filament\Concerns\TranslatableResource;
 use App\Filament\Tables\Columns\HabboBadgeColumn;
 use App\Models\User;
@@ -16,6 +17,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
 use LogicException;
 
 class BadgesRelationManager extends RelationManager
@@ -71,6 +73,14 @@ class BadgesRelationManager extends RelationManager
             ])
             ->headerActions([
                 CreateAction::make()
+                    ->using(function (array $data, RelationManager $livewire): Model {
+                        $user = self::owner($livewire);
+                        $badges = app(BadgeRepository::class);
+
+                        $badges->grant($user, $data['badge_code']);
+
+                        return $badges->relation($user)->where('badge_code', $data['badge_code'])->firstOrFail();
+                    })
                     ->before(function (CreateAction $action, RelationManager $livewire): void {
                         $user = self::owner($livewire);
 

--- a/app/Services/Badge/BadgeGrantMutex.php
+++ b/app/Services/Badge/BadgeGrantMutex.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\Badge;
+
+use Closure;
+use Illuminate\Support\Facades\DB;
+
+final readonly class BadgeGrantMutex
+{
+    /**
+     * Callers that own an outer transaction must retry concurrency errors
+     * there, since a nested savepoint cannot refresh its read snapshot.
+     *
+     * @param  Closure(): void  $grant
+     */
+    public function run(string $code, Closure $grant): void
+    {
+        $key = hash('sha256', strtolower($code));
+
+        DB::transaction(function () use ($key, $grant): void {
+            DB::table('website_badge_grant_locks')->insertOrIgnore(['lock_key' => $key]);
+            DB::table('website_badge_grant_locks')->where('lock_key', $key)->lockForUpdate()->first();
+
+            try {
+                $grant();
+            } finally {
+                // The database retains this lock until the outermost commit
+                // or rollback, without accumulating one mutex row per code.
+                DB::table('website_badge_grant_locks')->where('lock_key', $key)->delete();
+            }
+        }, attempts: 3);
+    }
+}

--- a/database/migrations/2026_09_07_000000_create_website_badge_grant_locks_table.php
+++ b/database/migrations/2026_09_07_000000_create_website_badge_grant_locks_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('website_badge_grant_locks', function (Blueprint $table): void {
+            $table->char('lock_key', 64)->primary();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('website_badge_grant_locks');
+    }
+};

--- a/tests/Ada/RepositoryConformanceTest.php
+++ b/tests/Ada/RepositoryConformanceTest.php
@@ -21,9 +21,8 @@ use App\Services\HousekeepingPermissionsService;
 use App\Services\PermissionsService;
 use Database\Seeders\HousekeepingPermissionSeeder;
 use Database\Seeders\WebsitePermissionSeeder;
-use Illuminate\Contracts\Cache\LockTimeoutException;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -303,23 +302,14 @@ test('the ada installer waits on a database ada has not finished building', func
     }
 });
 
-test('a grant held up by a competing one still leaves a single row', function () {
-    // The race is read-then-insert with no constraint behind it, so a
-    // sequential duplicate cannot reproduce it. Holding the lock and writing
-    // the row underneath stands in for the competing process: the grant has
-    // to notice the row appeared while it was waiting.
+test('owning a duplicate definition still makes a badge grant a no-op', function () {
     $badges = app(BadgeRepository::class);
     $user = User::factory()->create();
     $code = 'ACH_Race';
 
-    $lock = Cache::lock("ada-badge-grant:{$user->id}:" . sha1($code), 10);
-
-    expect($lock->get())->toBeTrue();
-
+    DB::table('badges')->insert(['code' => $code]);
     $badgeId = DB::table('badges')->insertGetId(['code' => $code]);
     DB::table('player_badges')->insert(['player_id' => $user->id, 'badge_id' => $badgeId, 'slot' => 0]);
-
-    $lock->release();
 
     $badges->grant($user, $code);
 
@@ -327,26 +317,45 @@ test('a grant held up by a competing one still leaves a single row', function ()
         ->and(DB::table('player_badges')->where('player_id', $user->id)->count())->toBe(1);
 });
 
-test('a grant that cannot take the lock does not write a duplicate', function () {
+test('rolling back a badge grant permits a subsequent successful grant', function () {
     $badges = app(BadgeRepository::class);
     $user = User::factory()->create();
     $code = 'ACH_Contended';
 
+    expect(fn () => DB::transaction(function () use ($badges, $user, $code): void {
+        $badges->grant($user, $code);
+
+        throw new RuntimeException('Purchase failed');
+    }))->toThrow(RuntimeException::class, 'Purchase failed');
+
+    expect($badges->codes($user))->toBe([])
+        ->and(DB::table('badges')->where('code', $code)->count())->toBe(0)
+        ->and(DB::table('website_badge_grant_locks')->count())->toBe(0);
+
     $badges->grant($user, $code);
-
-    // A competitor holding the lock past the wait window must make the grant
-    // fail loudly rather than fall through and insert a second row.
-    $lock = Cache::lock("ada-badge-grant:{$user->id}:" . sha1($code), 30);
-    expect($lock->get())->toBeTrue();
-
-    try {
-        expect(fn () => $badges->grant($user, $code))->toThrow(LockTimeoutException::class);
-    } finally {
-        $lock->release();
-    }
 
     expect(DB::table('player_badges')->where('player_id', $user->id)->count())->toBe(1);
 });
+
+test('concurrent Ada grants share one definition through outer transactions', function (bool $differentPlayers) {
+    $result = Process::env([
+        'APP_ENV' => 'testing',
+        'DB_DATABASE' => DB::connection()->getDatabaseName(),
+        'EMULATOR_DRIVER' => 'ada',
+    ])->timeout(15)->run([
+        PHP_BINARY, base_path('tests/Fixtures/concurrent-badge-grants.php'),
+        'ada', 'coordinator', sys_get_temp_dir() . '/atom-badge-race-' . bin2hex(random_bytes(8)),
+        $differentPlayers ? 'different' : 'same',
+    ]);
+
+    expect($result->successful())->toBeTrue($result->errorOutput())
+        ->and(json_decode(trim($result->output()), true, flags: JSON_THROW_ON_ERROR))
+        ->toBe([
+            'driver' => 'ada',
+            'ownership_rows' => $differentPlayers ? 2 : 1,
+            'definition_rows' => 1,
+        ]);
+})->with([true, false]);
 
 test('ada grants a large quantity in bounded chunks', function () {
     $furniture = app(FurnitureRepository::class);

--- a/tests/Feature/Emulator/BadgeManagerTest.php
+++ b/tests/Feature/Emulator/BadgeManagerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Emulator\Contracts\BadgeRepository;
+use App\Filament\Resources\User\Users\Pages\EditUser;
+use App\Filament\Resources\User\Users\RelationManagers\BadgesRelationManager;
+use App\Models\User;
+use Filament\Actions\CreateAction;
+use Filament\Actions\Testing\TestAction;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    installHotel();
+    grantHousekeepingPermission('can_access_housekeeping', 6);
+    grantHousekeepingPermission('edit_user', 6);
+    $this->actingAs(User::factory()->create(['rank' => 7]));
+    Filament::setCurrentPanel(Filament::getPanel('housekeeping'));
+});
+
+test('housekeeping grants offline badges once and preserves equipped ownership', function () {
+    $user = User::factory()->create();
+    $badges = app(BadgeRepository::class);
+    $manager = Livewire::test(BadgesRelationManager::class, [
+        'ownerRecord' => $user,
+        'pageClass' => EditUser::class,
+    ]);
+
+    $manager->callAction(TestAction::make(CreateAction::class)->table(), data: ['badge_code' => 'ADMIN_ONCE'])
+        ->assertHasNoActionErrors();
+
+    expect($badges->codes($user))->toBe(['ADMIN_ONCE']);
+
+    $badges->relation($user)->update(['slot_id' => 3]);
+
+    $manager->callAction(TestAction::make(CreateAction::class)->table(), data: ['badge_code' => 'ADMIN_ONCE'])
+        ->assertHasNoActionErrors();
+
+    expect($badges->codes($user))->toBe(['ADMIN_ONCE'])
+        ->and($badges->relation($user)->value('slot_id'))->toBe(3)
+        ->and($this->rcon->calls)->toBe([]);
+});
+
+test('housekeeping sends online badges only through connected RCON', function (bool $connected) {
+    $user = User::factory()->create(['online' => '1'])->refresh();
+    $this->rcon->connected($connected);
+
+    Livewire::test(BadgesRelationManager::class, [
+        'ownerRecord' => $user,
+        'pageClass' => EditUser::class,
+    ])->callAction(TestAction::make(CreateAction::class)->table(), data: ['badge_code' => 'ADMIN_ONLINE'])
+        ->assertHasNoActionErrors()
+        ->assertNotified($connected ? 'Badge sent through the emulator' : 'RCON is not connected!');
+
+    expect(app(BadgeRepository::class)->codes($user))->toBe([])
+        ->and(array_column($this->rcon->calls, 'method'))->toBe($connected ? ['giveBadge'] : []);
+})->with([true, false]);

--- a/tests/Feature/Emulator/BadgeRepositoryTest.php
+++ b/tests/Feature/Emulator/BadgeRepositoryTest.php
@@ -4,6 +4,8 @@ use App\Emulator\Contracts\BadgeRepository;
 use App\Emulator\Data\OwnedBadge;
 use App\Emulator\Drivers\Arcturus\ArcturusBadgeRepository;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Process;
 
 /**
  * Arcturus half of the badge conformance suite. Ada owns overlapping table
@@ -108,4 +110,18 @@ test('deleting a badge model removes only that row', function () {
 
     expect($badges->relation($user)->pluck('badge_code')->all())->toBe(['ACH_Keep1'])
         ->and($keep->fresh())->not->toBeNull();
+});
+
+test('concurrent Arcturus grants remain unique through outer transactions', function () {
+    $result = Process::env([
+        'APP_ENV' => 'testing',
+        'DB_DATABASE' => DB::connection()->getDatabaseName(),
+        'EMULATOR_DRIVER' => 'arcturus',
+    ])->timeout(15)->run([
+        PHP_BINARY, base_path('tests/Fixtures/concurrent-badge-grants.php'), 'arcturus',
+    ]);
+
+    expect($result->successful())->toBeTrue($result->errorOutput())
+        ->and(json_decode(trim($result->output()), true, flags: JSON_THROW_ON_ERROR))
+        ->toBe(['driver' => 'arcturus', 'ownership_rows' => 1, 'definition_rows' => null]);
 });

--- a/tests/Fixtures/concurrent-badge-grants.php
+++ b/tests/Fixtures/concurrent-badge-grants.php
@@ -1,0 +1,92 @@
+<?php
+
+// Separate processes reproduce grants whose surrounding transactions overlap.
+// Clone the real badge table shapes so DDL and committed writes never touch
+// the test suite's player data or its RefreshDatabase transaction.
+
+use App\Emulator\Drivers\Ada\AdaBadgeRepository;
+use App\Emulator\Drivers\Arcturus\ArcturusBadgeRepository;
+use App\Models\User;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\Process\Process;
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+$app = require dirname(__DIR__, 2) . '/bootstrap/app.php';
+$app->make(Kernel::class)->bootstrap();
+$driver = $argv[1];
+$differentPlayers = ($argv[4] ?? 'same') === 'different';
+$mode = $argv[2] ?? 'coordinator';
+$directory = $argv[3] ?? sys_get_temp_dir() . '/atom-badge-race-' . uniqid();
+$prefix = 'badge_race_' . substr(hash('sha256', $directory), 0, 12) . '_';
+$tables = $driver === 'ada' ? ['badges', 'player_badges', 'website_badge_grant_locks'] : ['users_badges', 'website_badge_grant_locks'];
+$connection = DB::connection();
+
+if ($mode === 'coordinator') {
+    mkdir($directory, 0700);
+    foreach ($tables as $table) {
+        $connection->statement("DROP TABLE IF EXISTS `{$prefix}{$table}`");
+        $connection->statement("CREATE TABLE `{$prefix}{$table}` LIKE `{$table}`");
+    }
+    try {
+        $first = new Process([PHP_BINARY, __FILE__, $driver, 'first', $directory, $differentPlayers ? 'different' : 'same'], timeout: 10);
+        $second = new Process([PHP_BINARY, __FILE__, $driver, 'second', $directory, $differentPlayers ? 'different' : 'same'], timeout: 10);
+        $first->start();
+        $second->start();
+        $first->wait();
+        $second->wait();
+        if (! $first->isSuccessful() || ! $second->isSuccessful() || trim($first->getOutput()) !== 'completed' || trim($second->getOutput()) !== 'completed') {
+            throw new RuntimeException($first->getOutput() . $first->getErrorOutput() . $second->getOutput() . $second->getErrorOutput());
+        }
+        $ownedTable = $driver === 'ada' ? 'player_badges' : 'users_badges';
+        $owned = $connection->table($prefix . $ownedTable)->count();
+        $definitions = $driver === 'ada' ? $connection->table($prefix . 'badges')->count() : null;
+        echo json_encode(['driver' => $driver, 'ownership_rows' => $owned, 'definition_rows' => $definitions]) . PHP_EOL;
+    } finally {
+        if (isset($first)) {
+            $first->stop(0.1);
+        }
+        if (isset($second)) {
+            $second->stop(0.1);
+        }
+        foreach ($tables as $table) {
+            $connection->statement("DROP TABLE IF EXISTS `{$prefix}{$table}`");
+        }
+        foreach (glob($directory . '/*') as $file) {
+            unlink($file);
+        }
+        rmdir($directory);
+    }
+    exit;
+}
+
+$connection->setTablePrefix($prefix);
+$user = new User;
+$user->forceFill(['id' => $differentPlayers && $mode === 'second' ? 9999998 : 9999999]);
+$badges = $driver === 'ada' ? new AdaBadgeRepository : new ArcturusBadgeRepository;
+$waitFor = function (string $file): void {
+    $deadline = microtime(true) + 5;
+    while (! is_file($file)) {
+        if (microtime(true) > $deadline) {
+            throw new RuntimeException('Timed out waiting for competing grant.');
+        }
+        usleep(10000);
+    }
+};
+if ($mode === 'first') {
+    DB::transaction(function () use ($badges, $user, $directory, $waitFor): void {
+        $badges->grant($user, 'ACH_Concurrent');
+        touch($directory . '/first-granted');
+        $waitFor($directory . '/second-started');
+        usleep(300000);
+    }, attempts: 3);
+} else {
+    $waitFor($directory . '/first-granted');
+    DB::transaction(function () use ($badges, $user, $directory, $driver): void {
+        DB::table($driver === 'ada' ? 'player_badges' : 'users_badges')->count();
+        touch($directory . '/second-started');
+        $badges->grant($user, 'ACH_Concurrent');
+    }, attempts: 3);
+}
+
+echo 'completed';


### PR DESCRIPTION
## Why

Serialize badge grants through transaction commit and use the same repository for offline admin grants so concurrent requests cannot create duplicate ownership.

## Testing

- [ ] Run `php artisan migrate --force` on a test installation.
- [ ] In `/housekeeping/users`, open an offline user’s Badges relation and grant the same badge twice; confirm it appears once and any equipped slot is preserved.
- [ ] Grant a badge to an online user with the emulator connected and confirm it appears in the client.
