### PR TITLE
fix(auth): use the configured origin in password reset links

### DIFF
--- a/app/Mail/ResetPasswordMail.php
+++ b/app/Mail/ResetPasswordMail.php
@@ -22,6 +22,12 @@ class ResetPasswordMail extends Mailable implements ShouldQueue
 
     public function content(): Content
     {
-        return new Content(view: 'email.forgetPassword');
+        return new Content(
+            view: 'email.forgetPassword',
+            with: [
+                'resetUrl' => rtrim((string) config('app.url'), '/')
+                    . route('reset.password.get', $this->token, absolute: false),
+            ],
+        );
     }
 }

--- a/resources/themes/atom/views/email/forgetPassword.blade.php
+++ b/resources/themes/atom/views/email/forgetPassword.blade.php
@@ -1,4 +1,4 @@
 <h1>{{ __('Reset your password') }}</h1>
 
 {{ __('Click the link to reset your password:') }}
-<a href="{{ route('reset.password.get', $token) }}">{{ __('Reset Password') }}</a>
+<a href="{{ $resetUrl }}">{{ __('Reset Password') }}</a>

--- a/tests/Feature/Auth/PasswordResetOriginTest.php
+++ b/tests/Feature/Auth/PasswordResetOriginTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Mail\ResetPasswordMail;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+
+test('password reset mail uses the configured origin despite an untrusted request host', function () {
+    installHotel();
+    setSetting('theme', 'atom');
+    Mail::fake();
+    config(['app.url' => 'https://hotel.example']);
+
+    $user = User::factory()->create();
+
+    $this->post('http://untrusted.example/forgot-password', ['mail' => $user->mail])
+        ->assertSessionHas('success');
+
+    Mail::assertQueued(ResetPasswordMail::class, function (ResetPasswordMail $mail): bool {
+        $html = $mail->render();
+
+        expect($html)->toContain('https://hotel.example/reset-password/' . $mail->token)
+            ->not->toContain('untrusted.example');
+
+        return true;
+    });
+});


### PR DESCRIPTION
## Why

Build password-reset email links from APP_URL so an untrusted request Host cannot redirect users and expose their reset tokens.
