### PR TITLE
fix(theme): preserve configured parent theme inheritance

### DIFF
--- a/app/Http/Middleware/SetThemeMiddleware.php
+++ b/app/Http/Middleware/SetThemeMiddleware.php
@@ -14,9 +14,9 @@ class SetThemeMiddleware
         $theme = setting('theme');
 
         if (empty($theme) || $theme === '1') {
-            Theme::set('atom');
+            Theme::set('atom', config('theme.parent'));
         } else {
-            Theme::set($theme);
+            Theme::set($theme, config('theme.parent'));
         }
 
         return $next($request);

--- a/tests/Feature/Middleware/ThemeInheritanceTest.php
+++ b/tests/Feature/Middleware/ThemeInheritanceTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Mail\ResetPasswordMail;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+
+test('Dusk renders password reset mail through the configured parent theme', function () {
+    installHotel();
+    setSetting('theme', 'dusk');
+    config(['theme.parent' => 'atom']);
+    Mail::fake();
+
+    $user = User::factory()->create();
+
+    $this->post(route('forgot.password.post'), ['mail' => $user->mail])
+        ->assertSessionHas('success');
+
+    Mail::assertQueued(ResetPasswordMail::class, function (ResetPasswordMail $mail): bool {
+        expect($mail->render())->toContain('/reset-password/' . $mail->token);
+
+        return true;
+    });
+});


### PR DESCRIPTION
## Why

Retain the configured parent when selecting a theme so Dusk can render shared views, including password-reset emails.
