### PR TITLE
fix(captcha): require enabled challenges across both themes

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -182,7 +182,7 @@ class CreateNewUser implements CreatesNewUsers
             'beta_code' => [Rule::requiredIf(setting('requires_beta_code') === '1'), 'nullable', 'string', new BetaCodeRule],
             'referral_code' => ['nullable', 'string', 'max:255'],
             'terms' => ['required', 'accepted'],
-            'g-recaptcha-response' => ['sometimes', 'string', new GoogleRecaptchaRule],
+            'g-recaptcha-response' => [new GoogleRecaptchaRule],
             'cf-turnstile-response' => [new CloudflareTurnstileRule],
         ];
 

--- a/app/Rules/GoogleRecaptchaRule.php
+++ b/app/Rules/GoogleRecaptchaRule.php
@@ -4,15 +4,23 @@ namespace App\Rules;
 
 use App\Support\OutboundHttp;
 use Closure;
-use Illuminate\Contracts\Validation\InvokableRule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Http\Client\ConnectionException;
 
-class GoogleRecaptchaRule implements InvokableRule
+class GoogleRecaptchaRule implements ValidationRule
 {
-    public function __invoke(string $attribute, mixed $value, Closure $fail): void
+    public bool $implicit = true;
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         // If recaptcha is disabled
         if (! (int) setting('google_recaptcha_enabled')) {
+            return;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            $fail(__('The Google recaptcha must be completed'));
+
             return;
         }
 

--- a/resources/themes/dusk/views/layouts/app.blade.php
+++ b/resources/themes/dusk/views/layouts/app.blade.php
@@ -93,6 +93,10 @@
 
         <x-fancybox-assets />
 
+        @if (setting('google_recaptcha_enabled'))
+            <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+        @endif
+
         @stack('javascript')
 
         @stack('scripts')

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Testing\TestResponse;
 
 function register(array $overrides = []): TestResponse
@@ -161,4 +162,56 @@ test('an enabled turnstile without configured keys does not block registration',
     register()->assertRedirect(RouteServiceProvider::HOME);
 
     $this->assertAuthenticated();
+});
+
+test('enabled recaptcha rejects missing or malformed registration tokens without making a verification request', function (array $input) {
+    installHotel();
+    setSetting('google_recaptcha_enabled', '1');
+    Http::preventStrayRequests();
+
+    register($input)->assertSessionHasErrors('g-recaptcha-response');
+
+    $this->assertGuest();
+    expect(User::where('username', 'Tester')->exists())->toBeFalse();
+    Http::assertNothingSent();
+})->with([
+    'omitted' => [[]],
+    'blank' => [['g-recaptcha-response' => '   ']],
+    'non-string' => [['g-recaptcha-response' => ['unexpected']]],
+]);
+
+test('a verified recaptcha allows registration', function () {
+    installHotel();
+    setSetting('google_recaptcha_enabled', '1');
+    config()->set('habbo.site.recaptcha_secret_key', 'test-secret');
+    Http::fake(['www.google.com/recaptcha/api/siteverify' => Http::response(['success' => true])]);
+
+    register(['g-recaptcha-response' => 'verified-token'])->assertRedirect(RouteServiceProvider::HOME);
+
+    $this->assertAuthenticated();
+    Http::assertSent(fn ($request) => $request->url() === 'https://www.google.com/recaptcha/api/siteverify'
+        && $request['secret'] === 'test-secret'
+        && $request['response'] === 'verified-token');
+});
+
+test('a rejected recaptcha prevents registration', function () {
+    installHotel();
+    setSetting('google_recaptcha_enabled', '1');
+    Http::fake(['www.google.com/recaptcha/api/siteverify' => Http::response(['success' => false])]);
+
+    register(['g-recaptcha-response' => 'rejected-token'])->assertSessionHasErrors('g-recaptcha-response');
+
+    $this->assertGuest();
+    expect(User::where('username', 'Tester')->exists())->toBeFalse();
+});
+
+test('disabled recaptcha allows registration without contacting Google', function () {
+    installHotel();
+    setSetting('google_recaptcha_enabled', '0');
+    Http::preventStrayRequests();
+
+    register()->assertRedirect(RouteServiceProvider::HOME);
+
+    $this->assertAuthenticated();
+    Http::assertNothingSent();
 });

--- a/tests/Feature/Pages/CaptchaAssetsTest.php
+++ b/tests/Feature/Pages/CaptchaAssetsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\User;
+
+beforeEach(function () {
+    installHotel();
+
+    config([
+        'habbo.site.recaptcha_site_key' => 'google-test-site-key',
+        'services.turnstile.key' => 'turnstile-test-site-key',
+    ]);
+});
+
+test('captcha forms load the enabled google widget script once', function (string $theme, string $route) {
+    setSetting('theme', $theme);
+    setSetting('google_recaptcha_enabled', '1');
+
+    if ($route === 'settings.password.show') {
+        $this->actingAs(User::factory()->create());
+    }
+
+    $response = $this->get(route($route))
+        ->assertOk()
+        ->assertSee('data-sitekey="google-test-site-key"', escape: false);
+
+    expect(substr_count($response->getContent(), 'https://www.google.com/recaptcha/api.js'))->toBe(1);
+})->with(['atom', 'dusk'])->with(['register', 'settings.password.show']);
+
+test('disabling google leaves turnstile available on registration forms', function (string $theme) {
+    setSetting('theme', $theme);
+    setSetting('google_recaptcha_enabled', '0');
+    setSetting('cloudflare_turnstile_enabled', '1');
+
+    $this->get(route('register'))
+        ->assertOk()
+        ->assertDontSee('https://www.google.com/recaptcha/api.js', escape: false)
+        ->assertDontSee('data-sitekey="google-test-site-key"', escape: false)
+        ->assertSee('https://challenges.cloudflare.com/turnstile/v0/api.js', escape: false)
+        ->assertSee('turnstile-test-site-key', escape: false);
+})->with(['atom', 'dusk']);

--- a/tests/Feature/Services/OutboundHttpTest.php
+++ b/tests/Feature/Services/OutboundHttpTest.php
@@ -92,7 +92,7 @@ test('recaptcha rejects unsuccessful verification responses', function () {
     ]);
     $failure = null;
 
-    (new GoogleRecaptchaRule)('g-recaptcha-response', 'invalid-token', function (string $message) use (&$failure): void {
+    (new GoogleRecaptchaRule)->validate('g-recaptcha-response', 'invalid-token', function (string $message) use (&$failure): void {
         $failure = $message;
     });
 


### PR DESCRIPTION
## Why

Require valid tokens when Google reCAPTCHA is enabled and load the widget in Dusk so supported themes can submit protected forms.

## Testing

- [ ] With valid Google reCAPTCHA keys configured, enable Google reCAPTCHA and open `/register` in both Atom and Dusk; complete the challenge and confirm registration succeeds.
- [ ] Disable Google reCAPTCHA and confirm forms still follow the configured Turnstile setting.
