### PR TITLE
fix(auth): revoke stale sessions after password changes

### DIFF
--- a/app/Http/Controllers/User/PasswordSettingsController.php
+++ b/app/Http/Controllers/User/PasswordSettingsController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\PasswordSettingsFormRequest;
 use App\Support\AuthenticatedUser;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\View\View;
 
 class PasswordSettingsController extends Controller
@@ -18,9 +17,7 @@ class PasswordSettingsController extends Controller
 
     public function update(PasswordSettingsFormRequest $request): RedirectResponse
     {
-        AuthenticatedUser::from($request)->update([
-            'password' => Hash::make($request->input('password')),
-        ]);
+        AuthenticatedUser::from($request)->changePassword($request->validated('password'));
 
         return redirect()->route('settings.password.show')->with('success', __('Your password has been changed!'));
     }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -71,6 +71,7 @@ class Kernel extends HttpKernel
             EncryptCookies::class,
             AddQueuedCookiesToResponse::class,
             StartSession::class,
+            AuthenticateSession::class,
             ShareErrorsFromSession::class,
             VerifyCsrfToken::class,
             SubstituteBindings::class,

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Http;
 
 use App\Http\Middleware\Authenticate;
+use App\Http\Middleware\AuthenticateSession;
 use App\Http\Middleware\BannedMiddleware;
 use App\Http\Middleware\ConfigureRuntimeFilesystems;
 use App\Http\Middleware\EncryptCookies;
@@ -33,7 +34,6 @@ use Illuminate\Http\Middleware\SetCacheHeaders;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Routing\Middleware\ThrottleRequests;
 use Illuminate\Routing\Middleware\ValidateSignature;
-use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;

--- a/app/Http/Middleware/AuthenticateHousekeepingSession.php
+++ b/app/Http/Middleware/AuthenticateHousekeepingSession.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Filament\Facades\Filament;
+use Illuminate\Http\Request;
+
+class AuthenticateHousekeepingSession extends AuthenticateSession
+{
+    protected function redirectTo(Request $request): ?string
+    {
+        return Filament::getLoginUrl();
+    }
+}

--- a/app/Http/Middleware/AuthenticateSession.php
+++ b/app/Http/Middleware/AuthenticateSession.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Auth\SessionGuard;
+use Illuminate\Http\Request;
+use Illuminate\Session\Middleware\AuthenticateSession as Middleware;
+
+class AuthenticateSession extends Middleware
+{
+    /**
+     * @param  Request  $request
+     */
+    public function handle($request, Closure $next): mixed
+    {
+        $guard = $this->auth->guard();
+
+        // Existing sessions predate password tracking. Only a fresh login can
+        // establish their fingerprint safely after a password may have changed.
+        if ($request->hasSession()
+            && $request->user() !== null
+            && $guard instanceof SessionGuard
+            && $request->session()->has($guard->getName())
+            && ! $request->session()->has('password_hash_' . $this->auth->getDefaultDriver())) {
+            $this->logout($request);
+        }
+
+        return parent::handle($request, $next);
+    }
+}

--- a/app/Listeners/StoreSessionPasswordHash.php
+++ b/app/Listeners/StoreSessionPasswordHash.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\SessionGuard;
+use Illuminate\Support\Facades\Auth;
+
+class StoreSessionPasswordHash
+{
+    public function handle(Login $event): void
+    {
+        $guard = Auth::guard($event->guard);
+
+        if ($guard instanceof SessionGuard) {
+            $guard->getSession()->put(
+                'password_hash_' . $event->guard,
+                $guard->hashPasswordForCookie($event->user->getAuthPassword()),
+            );
+        }
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -42,6 +42,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Sanctum\HasApiTokens;
 use Laravel\Sanctum\PersonalAccessToken;
@@ -54,6 +55,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property string $username
  * @property string $real_name
  * @property string $password
+ * @property string|null $website_remember_token
  * @property string|null $two_factor_secret
  * @property string|null $two_factor_recovery_codes
  * @property Carbon|null $two_factor_confirmed_at
@@ -172,6 +174,8 @@ class User extends Authenticatable implements FilamentUser, HasName
 
     public $timestamps = false;
 
+    protected $rememberTokenName = 'website_remember_token';
+
     /**
      * Every user query is refreshed from the active emulator in one pass.
      *
@@ -211,6 +215,7 @@ class User extends Authenticatable implements FilamentUser, HasName
         'id',
         'password',
         'remember_token',
+        'website_remember_token',
         'auth_ticket',
         'mail',
         'ip_register',
@@ -386,6 +391,7 @@ class User extends Authenticatable implements FilamentUser, HasName
     public function changePassword(string $newPassword): void
     {
         $this->password = Hash::make($newPassword);
+        $this->setRememberToken(Str::random(60));
         $this->save();
     }
 

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -11,6 +11,7 @@ use App\Policies\WebsiteArticleCommentPolicy;
 use App\Policies\WebsiteHelpCenterTicketPolicy;
 use App\Policies\WebsiteHelpCenterTicketReplyPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Session\Middleware\AuthenticateSession;
 use Spatie\Activitylog\Models\Activity;
 
 class AuthServiceProvider extends ServiceProvider
@@ -32,6 +33,6 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        AuthenticateSession::redirectUsing(fn (): string => route('login'));
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Emulator\Contracts\RankRepository;
+use App\Listeners\StoreSessionPasswordHash;
 use App\Models\Community\Staff\WebsiteOpenPosition;
 use App\Models\Community\Teams\WebsiteTeam;
 use App\Models\User;
@@ -11,6 +12,7 @@ use App\Observers\CommunityCacheObserver;
 use App\Observers\UserObserver;
 use App\Observers\WebsiteAdObserver;
 use App\Observers\WebsiteOpenPositionObserver;
+use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -24,6 +26,9 @@ class EventServiceProvider extends ServiceProvider
      * @var array<class-string, array<int, class-string>>
      */
     protected $listen = [
+        Login::class => [
+            StoreSessionPasswordHash::class,
+        ],
         Registered::class => [
             SendEmailVerificationNotification::class,
         ],

--- a/app/Providers/Filament/AdminFilamentPanelProvider.php
+++ b/app/Providers/Filament/AdminFilamentPanelProvider.php
@@ -3,11 +3,11 @@
 namespace App\Providers\Filament;
 
 use App\Filament\Pages\Login;
+use App\Http\Middleware\AuthenticateHousekeepingSession;
 use App\Http\Middleware\BannedMiddleware;
 use App\Http\Middleware\ForceStaffTwoFactorMiddleware;
 use App\Http\Middleware\MaintenanceMiddleware;
 use Filament\Http\Middleware\Authenticate;
-use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Panel;
@@ -48,12 +48,15 @@ class AdminFilamentPanelProvider extends PanelProvider
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,
                 StartSession::class,
-                AuthenticateSession::class,
+                AuthenticateHousekeepingSession::class,
                 ShareErrorsFromSession::class,
                 PreventRequestForgery::class,
                 SubstituteBindings::class,
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
+            ])
+            ->persistentMiddleware([
+                AuthenticateHousekeepingSession::class,
             ])
             ->authMiddleware([
                 Authenticate::class,

--- a/database/migrations/2026_09_07_204053_add_website_remember_token_to_users_table.php
+++ b/database/migrations/2026_09_07_204053_add_website_remember_token_to_users_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('users', 'website_remember_token')) {
+            Schema::table('users', function (Blueprint $table): void {
+                $table->string('website_remember_token', 100)->nullable();
+            });
+        }
+
+        // Some hotels added Laravel's default column themselves. Preserve their
+        // existing cookies while leaving the emulator-owned column untouched.
+        if (Schema::hasColumn('users', 'remember_token')) {
+            DB::table('users')
+                ->whereNull('website_remember_token')
+                ->whereNotNull('remember_token')
+                ->update(['website_remember_token' => DB::raw('remember_token')]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('website_remember_token');
+        });
+    }
+};

--- a/tests/Ada/PasswordSessionSecurityTest.php
+++ b/tests/Ada/PasswordSessionSecurityTest.php
@@ -6,6 +6,17 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 
+test('ada rejects a legacy session after a password change', function () {
+    installHotel();
+    $user = User::factory()->create();
+    $legacySession = [Auth::guard()->getName() => $user->id];
+
+    $user->changePassword('ChangedPassword123!');
+
+    $this->withSession($legacySession)->get(route('me.show'))->assertRedirect(route('login'));
+    $this->assertGuest();
+});
+
 test('ada remembered logins persist in CMS storage and are revoked after a password reset', function () {
     installHotel();
     $user = User::factory()->create();

--- a/tests/Ada/PasswordSessionSecurityTest.php
+++ b/tests/Ada/PasswordSessionSecurityTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Models\PasswordResetToken;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+test('ada remembered logins persist in CMS storage and are revoked after a password reset', function () {
+    installHotel();
+    $user = User::factory()->create();
+    $cookieName = Auth::guard()->getRecallerName();
+
+    $login = $this->post(route('login.store'), [
+        'username' => $user->username,
+        'password' => 'password',
+        'remember' => true,
+    ])->assertRedirect(route('me.show'))->assertCookie($cookieName);
+
+    $rememberedCookie = $login->getCookie($cookieName)->getValue();
+    expect($user->fresh()->getRememberToken())->not->toBeEmpty();
+
+    session()->flush();
+    Auth::forgetGuards();
+    $this->withCookie($cookieName, $rememberedCookie)->get(route('me.show'))->assertOk();
+    $this->assertAuthenticatedAs($user);
+
+    $oldSession = session()->all();
+    session()->flush();
+    Auth::forgetGuards();
+    $this->withCookies([$cookieName => '']);
+    PasswordResetToken::create([
+        'email' => $user->mail,
+        'token' => PasswordResetToken::hashToken('ada-reset-token'),
+    ]);
+
+    $this->post(route('reset.password.post', 'ada-reset-token'), [
+        'password' => 'ChangedPassword123!',
+        'password_confirmation' => 'ChangedPassword123!',
+    ])->assertRedirect(route('login'));
+
+    expect(Hash::check('ChangedPassword123!', DB::table('players')->where('id', $user->id)->value('password')))->toBeTrue();
+
+    Auth::forgetGuards();
+    $this->withSession($oldSession)->get(route('me.show'))->assertRedirect(route('login'));
+    $this->assertGuest();
+
+    Auth::forgetGuards();
+    $this->withCookie($cookieName, $rememberedCookie)->get(route('me.show'))->assertRedirect(route('login'));
+    $this->assertGuest();
+});

--- a/tests/Feature/Auth/HousekeepingSessionSecurityTest.php
+++ b/tests/Feature/Auth/HousekeepingSessionSecurityTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Filament\Pages\Dashboard;
+use App\Models\PasswordResetToken;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    installHotel();
+    setSetting('force_staff_2fa', '0');
+    grantHousekeepingPermission('can_access_housekeeping', 6);
+
+    $this->staff = User::factory()->create(['rank' => 6]);
+});
+
+test('a pre-upgrade staff session cannot enter housekeeping after a password reset', function () {
+    $legacySession = [Auth::guard()->getName() => $this->staff->id];
+
+    PasswordResetToken::create([
+        'email' => $this->staff->mail,
+        'token' => PasswordResetToken::hashToken('legacy-staff-reset-token'),
+    ]);
+
+    $this->post(route('reset.password.post', 'legacy-staff-reset-token'), [
+        'password' => 'ChangedPassword123!',
+        'password_confirmation' => 'ChangedPassword123!',
+    ])->assertRedirect(route('login'));
+
+    Auth::forgetGuards();
+    $this->withSession($legacySession)
+        ->get('/housekeeping')
+        ->assertRedirect(route('filament.housekeeping.auth.login'));
+    $this->assertGuest();
+});
+
+test('a fresh website login grants an eligible staff member housekeeping access', function () {
+    $this->post(route('login.store'), [
+        'username' => $this->staff->username,
+        'password' => 'password',
+    ])->assertRedirect(route('me.show'));
+
+    Auth::forgetGuards();
+    $this->get('/housekeeping')->assertOk();
+    $this->assertAuthenticatedAs($this->staff);
+});
+
+test('an unchanged password allows remembered housekeeping authentication', function () {
+    $this->staff->setRememberToken(Str::random(60));
+    $this->staff->save();
+    $guard = Auth::guard();
+    $cookie = $this->staff->id . '|' . $this->staff->getRememberToken() . '|' . $guard->hashPasswordForCookie($this->staff->password);
+
+    $this->withCookie($guard->getRecallerName(), $cookie)->get('/housekeeping')->assertOk();
+    $this->assertAuthenticatedAs($this->staff);
+});
+
+test('housekeeping livewire requests reject a session after its password changes', function () {
+    $page = $this->actingAs($this->staff)->get('/housekeeping')->assertOk();
+    $oldSession = session()->all();
+    $oldSession[Auth::guard()->getName()] = $this->staff->id;
+    preg_match_all('/wire:snapshot="([^"]+)"/', $page->getContent(), $matches);
+    $component = Livewire::new(Dashboard::class)->getName();
+    $snapshot = collect($matches[1])
+        ->map(fn (string $value) => html_entity_decode($value, ENT_QUOTES | ENT_HTML5))
+        ->first(fn (string $value) => json_decode($value, true, flags: JSON_THROW_ON_ERROR)['memo']['name'] === $component);
+
+    expect($snapshot)->toBeString();
+    $this->staff->changePassword('ChangedPassword123!');
+    Auth::forgetGuards();
+
+    $this->withSession($oldSession)->postJson(Livewire::getUpdateUri(), [
+        'components' => [[
+            'snapshot' => $snapshot,
+            'updates' => [],
+            'calls' => [['method' => '$refresh', 'params' => []]],
+        ]],
+    ], ['X-Livewire' => 'true'])->assertUnauthorized();
+
+    $this->assertGuest();
+});

--- a/tests/Feature/Auth/PasswordSessionSecurityTest.php
+++ b/tests/Feature/Auth/PasswordSessionSecurityTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use App\Models\PasswordResetToken;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+beforeEach(function () {
+    installHotel();
+    $this->user = User::factory()->create();
+});
+
+test('resetting a password rejects an existing authenticated session', function () {
+    $this->actingAs($this->user)->get(route('me.show'))->assertOk();
+    $oldSession = session()->all();
+    $oldSession[Auth::guard()->getName()] = $this->user->id;
+
+    session()->flush();
+    Auth::forgetGuards();
+    PasswordResetToken::create([
+        'email' => $this->user->mail,
+        'token' => PasswordResetToken::hashToken('reset-session-token'),
+    ]);
+
+    $this->post(route('reset.password.post', 'reset-session-token'), [
+        'password' => 'ChangedPassword123!',
+        'password_confirmation' => 'ChangedPassword123!',
+    ])->assertRedirect(route('login'));
+
+    Auth::forgetGuards();
+    $this->withSession($oldSession)->get(route('me.show'))->assertRedirect(route('login'));
+    $this->assertGuest();
+});
+
+test('resetting a password revokes the previous remember-me cookie', function () {
+    $this->user->setRememberToken(Str::random(60));
+    $this->user->save();
+    $guard = Auth::guard();
+    $cookieName = $guard->getRecallerName();
+    $cookie = $this->user->id . '|' . $this->user->getRememberToken() . '|' . $guard->hashPasswordForCookie($this->user->password);
+
+    PasswordResetToken::create([
+        'email' => $this->user->mail,
+        'token' => PasswordResetToken::hashToken('reset-cookie-token'),
+    ]);
+
+    $this->post(route('reset.password.post', 'reset-cookie-token'), [
+        'password' => 'ChangedPassword123!',
+        'password_confirmation' => 'ChangedPassword123!',
+    ])->assertRedirect(route('login'));
+
+    Auth::forgetGuards();
+    $this->withCookie($cookieName, $cookie)->get(route('me.show'))->assertRedirect(route('login'));
+    $this->assertGuest();
+});
+
+test('an unchanged password still allows remembered authentication', function () {
+    $this->user->setRememberToken(Str::random(60));
+    $this->user->save();
+    $guard = Auth::guard();
+    $cookie = $this->user->id . '|' . $this->user->getRememberToken() . '|' . $guard->hashPasswordForCookie($this->user->password);
+
+    $this->withCookie($guard->getRecallerName(), $cookie)->get(route('me.show'))->assertOk();
+    $this->assertAuthenticatedAs($this->user);
+    expect($this->user->toArray())->not->toHaveKey('website_remember_token');
+});
+
+test('changing a password preserves the current session and revokes remembered logins', function () {
+    $oldRememberToken = $this->user->getRememberToken();
+
+    $this->actingAs($this->user)->get(route('settings.password.show'))->assertOk();
+    $oldSession = session()->all();
+    $oldSession[Auth::guard()->getName()] = $this->user->id;
+    $this->put(route('settings.password.update'), [
+        'current_password' => 'password',
+        'password' => 'ChangedPassword123!',
+        'password_confirmation' => 'ChangedPassword123!',
+    ])->assertRedirect(route('settings.password.show'));
+
+    $this->get(route('me.show'))->assertOk();
+    $this->assertAuthenticatedAs($this->user);
+    expect($this->user->fresh()->getRememberToken())->not->toBe($oldRememberToken);
+
+    Auth::forgetGuards();
+    $this->withSession($oldSession)->get(route('me.show'))->assertRedirect(route('login'));
+    $this->assertGuest();
+});

--- a/tests/Feature/Auth/PasswordSessionSecurityTest.php
+++ b/tests/Feature/Auth/PasswordSessionSecurityTest.php
@@ -10,6 +10,35 @@ beforeEach(function () {
     $this->user = User::factory()->create();
 });
 
+test('a pre-upgrade session cannot survive a password reset before its first upgraded request', function () {
+    $legacySession = [Auth::guard()->getName() => $this->user->id];
+
+    PasswordResetToken::create([
+        'email' => $this->user->mail,
+        'token' => PasswordResetToken::hashToken('legacy-session-reset-token'),
+    ]);
+
+    $this->post(route('reset.password.post', 'legacy-session-reset-token'), [
+        'password' => 'ChangedPassword123!',
+        'password_confirmation' => 'ChangedPassword123!',
+    ])->assertRedirect(route('login'));
+
+    Auth::forgetGuards();
+    $this->withSession($legacySession)->get(route('me.show'))->assertRedirect(route('login'));
+    $this->assertGuest();
+});
+
+test('a fresh password login initializes the session fingerprint immediately', function () {
+    $this->post(route('login.store'), [
+        'username' => $this->user->username,
+        'password' => 'password',
+    ])->assertRedirect(route('me.show'))->assertSessionHas('password_hash_web');
+
+    Auth::forgetGuards();
+    $this->get(route('me.show'))->assertOk();
+    $this->assertAuthenticatedAs($this->user);
+});
+
 test('resetting a password rejects an existing authenticated session', function () {
     $this->actingAs($this->user)->get(route('me.show'))->assertOk();
     $oldSession = session()->all();

--- a/tests/Feature/Auth/RememberTokenMigrationTest.php
+++ b/tests/Feature/Auth/RememberTokenMigrationTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+test('the remember-token migration preserves an existing hotel token column', function () {
+    $user = User::factory()->create();
+    $migration = require database_path('migrations/2026_09_07_204053_add_website_remember_token_to_users_table.php');
+
+    Schema::table('users', function (Blueprint $table): void {
+        $table->rememberToken();
+    });
+
+    try {
+        DB::table('users')->where('id', $user->id)->update(['remember_token' => 'existing-hotel-token']);
+        $migration->down();
+        $migration->up();
+
+        expect($user->fresh()->getRememberToken())->toBe('existing-hotel-token')
+            ->and(DB::table('users')->where('id', $user->id)->value('remember_token'))->toBe('existing-hotel-token');
+
+        $user->refresh()->setRememberToken('rotated-cms-token');
+        $user->save();
+        $migration->up();
+
+        expect($user->fresh()->getRememberToken())->toBe('rotated-cms-token');
+    } finally {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('remember_token');
+        });
+    }
+});

--- a/tests/Feature/Community/ArticleInteractionsTest.php
+++ b/tests/Feature/Community/ArticleInteractionsTest.php
@@ -70,7 +70,7 @@ test('a reader cannot delete someone else\'s comment', function () {
     $comment = $article->comments()->first();
     $stranger = User::factory()->create(['rank' => 1]);
 
-    $this->actingAs($stranger)
+    $this->flushSession()->actingAs($stranger)
         ->delete(route('article.comment.destroy', $comment))
         ->assertForbidden();
 

--- a/tests/Feature/Pages/AccountPagesTest.php
+++ b/tests/Feature/Pages/AccountPagesTest.php
@@ -22,7 +22,7 @@ test('the logo generator is permission gated', function () {
         ->get(route('logo-generator.index'))
         ->assertRedirect(route('me.show'));
 
-    $this->actingAs(User::factory()->create(['rank' => 7]))
+    $this->flushSession()->actingAs(User::factory()->create(['rank' => 7]))
         ->get(route('logo-generator.index'))
         ->assertOk();
 });

--- a/tests/Feature/Shop/PaypalTest.php
+++ b/tests/Feature/Shop/PaypalTest.php
@@ -328,7 +328,7 @@ test('one PayPal capture cannot credit two different orders', function () {
         ->get(route('paypal.successful-transaction', ['token' => 'ORDER-9']))
         ->assertSessionHas('success');
 
-    $this->actingAs($secondUser)
+    $this->flushSession()->actingAs($secondUser)
         ->get(route('paypal.successful-transaction', ['token' => 'ORDER-10']))
         ->assertSessionHasErrors('message');
 

--- a/tests/Feature/User/UserMassAssignmentTest.php
+++ b/tests/Feature/User/UserMassAssignmentTest.php
@@ -25,6 +25,7 @@ test('privileged columns cannot be mass assigned', function () {
         'extra_rank' => 7,
         'auth_ticket' => 'hijacked-ticket',
         'team_id' => 1,
+        'website_remember_token' => 'hijacked-token',
         'motto' => 'Updated motto',
     ]);
 
@@ -36,6 +37,7 @@ test('privileged columns cannot be mass assigned', function () {
         ->and($user->extra_rank)->toBeNull()
         ->and($user->auth_ticket)->toBe('')
         ->and($user->team_id)->toBeNull()
+        ->and($user->getRememberToken())->toBe('')
         ->and($user->motto)->toBe('Updated motto');
 });
 


### PR DESCRIPTION
## Why

Invalidate stale sessions and remembered credentials after password changes across the site and housekeeping using CMS-owned token storage. Existing sessions without password fingerprints authenticate once to establish trustworthy tracking.

## Testing

- [ ] Run `php artisan migrate --force` on a test installation.
- [ ] Sign into the same staff account in two browser profiles, then change its password at `/user/settings/password`; confirm the other profile must sign in again at `/user/me` and `/housekeeping`.
- [ ] Repeat with Remember me enabled and confirm the old remembered session cannot authenticate after the password change.
