### PR TITLE
fix: preserve domain transaction integrity fixes

### DIFF
--- a/app/Actions/Shop/FulfillPackage.php
+++ b/app/Actions/Shop/FulfillPackage.php
@@ -66,21 +66,18 @@ final readonly class FulfillPackage
 
         [$currencyName, $amount] = explode(':', $item->type_value, 2);
         $currency = CurrencyTypes::fromCurrencyName($currencyName);
+        $amount = $this->positiveInteger($item, $amount);
 
-        if ($currency === null || (int) $amount <= 0) {
+        if ($currency === null || $amount > intdiv(PHP_INT_MAX, $quantity)) {
             throw self::misconfigured($item);
         }
 
-        $this->currencies->give($user, $currency, (int) $amount * $quantity);
+        $this->currencies->give($user, $currency, $amount * $quantity);
     }
 
     private function giveFurniture(User $user, WebsiteShopItem $item, int $quantity): void
     {
-        $baseItemId = (int) $item->type_value;
-
-        if ($baseItemId <= 0) {
-            throw self::misconfigured($item);
-        }
+        $baseItemId = $this->positiveInteger($item, $item->type_value);
 
         $this->furniture->grant($user, $baseItemId, $quantity);
     }
@@ -100,13 +97,20 @@ final readonly class FulfillPackage
 
     private function giveRank(User $user, WebsiteShopItem $item): void
     {
-        $rank = (int) $item->type_value;
+        $rank = $this->positiveInteger($item, $item->type_value);
 
-        if ($rank <= 0) {
+        $user->forceFill(['rank' => $rank])->save();
+    }
+
+    private function positiveInteger(WebsiteShopItem $item, string $value): int
+    {
+        $integer = filter_var(ltrim($value, '0'), FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+
+        if (! ctype_digit($value) || $integer === false) {
             throw self::misconfigured($item);
         }
 
-        $user->forceFill(['rank' => $rank])->save();
+        return $integer;
     }
 
     private static function misconfigured(WebsiteShopItem $item): ShopPurchaseException

--- a/app/Actions/Shop/PurchaseShopPackage.php
+++ b/app/Actions/Shop/PurchaseShopPackage.php
@@ -63,6 +63,10 @@ final readonly class PurchaseShopPackage
 
     private function ensurePackageEligibility(User $recipient, WebsiteShopPackage $package, User $buyer): void
     {
+        if (! $recipient->is($buyer) && ! $package->is_giftable) {
+            throw new ShopPurchaseException(__('This package is not giftable'));
+        }
+
         if (! $package->isAvailable()) {
             throw new ShopPurchaseException(__('This package is no longer available'));
         }
@@ -152,7 +156,7 @@ final readonly class PurchaseShopPackage
                 'website_shop_package_id' => $lockedPackage->id,
                 'gifted_to' => $lockedRecipient->is($lockedBuyer) ? null : $lockedRecipient->id,
             ]);
-        });
+        }, attempts: 3);
     }
 
     private function ensureWithinPurchaseLimit(User $buyer, WebsiteShopPackage $package): void

--- a/app/Console/Commands/AtomInstallCommand.php
+++ b/app/Console/Commands/AtomInstallCommand.php
@@ -316,13 +316,20 @@ class AtomInstallCommand extends Command
 
     private function replaceEnvValue(string $contents, string $key, string $value, string $path): string
     {
-        $line = str_contains($value, ' ') ? sprintf('%s="%s"', $key, $value) : sprintf('%s=%s', $key, $value);
+        $escaped = strtr($value, [
+            '\\' => '\\\\',
+            '"' => '\\"',
+            '$' => '\\$',
+            "\r" => '\\r',
+            "\n" => '\\n',
+        ]);
+        $line = sprintf('%s="%s"', $key, $escaped);
 
         if (preg_match("/^{$key}=.*$/m", $contents) !== 1) {
             return $contents . PHP_EOL . $line;
         }
 
-        $updated = preg_replace("/^{$key}=.*$/m", $line, $contents);
+        $updated = preg_replace_callback("/^{$key}=.*$/m", fn (): string => $line, $contents);
 
         if (! is_string($updated)) {
             throw new \RuntimeException("Unable to update {$key} in environment file: {$path}");

--- a/app/Console/Commands/ImportBadgeData.php
+++ b/app/Console/Commands/ImportBadgeData.php
@@ -6,7 +6,9 @@ use App\Models\WebsiteBadge;
 use App\Services\SettingsService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use RuntimeException;
 use Throwable;
 
 class ImportBadgeData extends Command
@@ -71,7 +73,13 @@ class ImportBadgeData extends Command
 
     private function processBadgeData(string $jsonPath): void
     {
-        $jsonData = File::json($jsonPath);
+        $document = json_decode(File::get($jsonPath), flags: JSON_THROW_ON_ERROR);
+
+        if (! is_object($document)) {
+            throw new RuntimeException('Nitro external texts must contain a JSON object.');
+        }
+
+        $jsonData = get_object_vars($document);
 
         // Extract badge names and descriptions
         $badgeNames = Collection::make($jsonData)
@@ -89,15 +97,18 @@ class ImportBadgeData extends Command
             'badge_description' => $badgeDescriptions->get($key, 'No description available'),
         ])->values();
 
-        // Upsert the combined data in chunks
-        $badgeData->chunk(self::CHUNK_SIZE)->each(function ($chunk) {
-            WebsiteBadge::upsert(
-                $chunk->toArray(),
-                ['badge_key'],
-                ['badge_name', 'badge_description'],
-            );
+        // A later chunk can fail after earlier definitions were updated.
+        // Keep the previous import intact unless every chunk succeeds.
+        DB::transaction(function () use ($badgeData): void {
+            $badgeData->chunk(self::CHUNK_SIZE)->each(function ($chunk) {
+                WebsiteBadge::upsert(
+                    $chunk->toArray(),
+                    ['badge_key'],
+                    ['badge_name', 'badge_description'],
+                );
 
-            $this->info('Processed ' . $chunk->count() . ' badges.');
+                $this->info('Processed ' . $chunk->count() . ' badges.');
+            });
         });
     }
 }

--- a/app/Emulator/Drivers/Ada/AdaBadgeRepository.php
+++ b/app/Emulator/Drivers/Ada/AdaBadgeRepository.php
@@ -6,10 +6,10 @@ use App\Emulator\Contracts\BadgeRepository;
 use App\Emulator\Data\OwnedBadge;
 use App\Models\Ada\AdaPlayerBadge;
 use App\Models\User;
+use App\Services\Badge\BadgeGrantMutex;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -21,11 +21,7 @@ use Illuminate\Support\Facades\DB;
  */
 class AdaBadgeRepository implements BadgeRepository
 {
-    /** How long a grant may hold its lock before it is considered abandoned. */
-    private const LOCK_SECONDS = 10;
-
-    /** How long a competing grant waits for its turn before giving up. */
-    private const LOCK_WAIT_SECONDS = 5;
+    public function __construct(private readonly BadgeGrantMutex $mutex = new BadgeGrantMutex) {}
 
     /** @return HasMany<AdaPlayerBadge, User> */
     public function relation(User $user): HasMany
@@ -40,36 +36,19 @@ class AdaBadgeRepository implements BadgeRepository
 
     public function grant(User $user, string $badge): void
     {
-        // Resolving the definition and claiming ownership are both
-        // read-then-insert, and Ada constrains neither table, so a transaction
-        // alone lets two concurrent grants both see absence and both write.
-        // Serialising on the pair keeps Atom's own grants single-file.
-        Cache::lock($this->lockFor($user, $badge), self::LOCK_SECONDS)->block(
-            self::LOCK_WAIT_SECONDS,
-            fn () => DB::transaction(function () use ($user, $badge): void {
-                $badgeId = $this->badgeId($badge);
+        // The code lock also serializes definitions shared by different
+        // players and remains held through an outer purchase transaction.
+        $this->mutex->run($badge, function () use ($user, $badge): void {
+            if ($this->badges($user)->where('badges.code', $badge)->lockForUpdate()->exists()) {
+                return;
+            }
 
-                $owned = DB::table('player_badges')
-                    ->where('player_id', $user->id)
-                    ->where('badge_id', $badgeId)
-                    ->exists();
-
-                if ($owned) {
-                    return;
-                }
-
-                DB::table('player_badges')->insert([
-                    'player_id' => $user->id,
-                    'badge_id' => $badgeId,
-                    'slot' => 0,
-                ]);
-            }),
-        );
-    }
-
-    private function lockFor(User $user, string $badge): string
-    {
-        return sprintf('ada-badge-grant:%d:%s', $user->id, sha1($badge));
+            DB::table('player_badges')->insert([
+                'player_id' => $user->id,
+                'badge_id' => $this->badgeId($badge),
+                'slot' => 0,
+            ]);
+        });
     }
 
     public function revoke(User $user, string $badge): void
@@ -98,7 +77,7 @@ class AdaBadgeRepository implements BadgeRepository
      */
     private function badgeId(string $code): int
     {
-        $existing = DB::table('badges')->where('code', $code)->orderBy('id')->value('id');
+        $existing = DB::table('badges')->where('code', $code)->orderBy('id')->lockForUpdate()->value('id');
 
         return (int) ($existing ?? DB::table('badges')->insertGetId(['code' => $code]));
     }

--- a/app/Emulator/Drivers/Arcturus/ArcturusBadgeRepository.php
+++ b/app/Emulator/Drivers/Arcturus/ArcturusBadgeRepository.php
@@ -6,6 +6,7 @@ use App\Emulator\Contracts\BadgeRepository;
 use App\Emulator\Data\OwnedBadge;
 use App\Models\Game\Player\UserBadge;
 use App\Models\User;
+use App\Services\Badge\BadgeGrantMutex;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Pagination\LengthAwarePaginator;
 
@@ -14,6 +15,8 @@ use Illuminate\Pagination\LengthAwarePaginator;
  */
 class ArcturusBadgeRepository implements BadgeRepository
 {
+    public function __construct(private readonly BadgeGrantMutex $mutex = new BadgeGrantMutex) {}
+
     /** @return HasMany<UserBadge, User> */
     public function relation(User $user): HasMany
     {
@@ -27,16 +30,18 @@ class ArcturusBadgeRepository implements BadgeRepository
 
     public function grant(User $user, string $badge): void
     {
-        // Neither emulator constrains ownership in the database, so the
-        // driver guarantees idempotency itself.
-        if ($this->relation($user)->where('badge_code', $badge)->exists()) {
-            return;
-        }
+        $this->mutex->run($badge, function () use ($user, $badge): void {
+            // Use a current read; MariaDB may instead require the outer
+            // transaction to retry when its earlier snapshot is stale.
+            if ($this->relation($user)->where('badge_code', $badge)->lockForUpdate()->exists()) {
+                return;
+            }
 
-        $this->relation($user)->create([
-            'slot_id' => 0,
-            'badge_code' => $badge,
-        ]);
+            $this->relation($user)->create([
+                'slot_id' => 0,
+                'badge_code' => $badge,
+            ]);
+        });
     }
 
     public function revoke(User $user, string $badge): void

--- a/app/Filament/Resources/User/Users/RelationManagers/BadgesRelationManager.php
+++ b/app/Filament/Resources/User/Users/RelationManagers/BadgesRelationManager.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\User\Users\RelationManagers;
 
 use App\Contracts\Rcon;
+use App\Emulator\Contracts\BadgeRepository;
 use App\Filament\Concerns\TranslatableResource;
 use App\Filament\Tables\Columns\HabboBadgeColumn;
 use App\Models\User;
@@ -16,6 +17,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
 use LogicException;
 
 class BadgesRelationManager extends RelationManager
@@ -71,6 +73,14 @@ class BadgesRelationManager extends RelationManager
             ])
             ->headerActions([
                 CreateAction::make()
+                    ->using(function (array $data, RelationManager $livewire): Model {
+                        $user = self::owner($livewire);
+                        $badges = app(BadgeRepository::class);
+
+                        $badges->grant($user, $data['badge_code']);
+
+                        return $badges->relation($user)->where('badge_code', $data['badge_code'])->firstOrFail();
+                    })
                     ->before(function (CreateAction $action, RelationManager $livewire): void {
                         $user = self::owner($livewire);
 

--- a/app/Services/Badge/BadgeGrantMutex.php
+++ b/app/Services/Badge/BadgeGrantMutex.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\Badge;
+
+use Closure;
+use Illuminate\Support\Facades\DB;
+
+final readonly class BadgeGrantMutex
+{
+    /**
+     * Callers that own an outer transaction must retry concurrency errors
+     * there, since a nested savepoint cannot refresh its read snapshot.
+     *
+     * @param  Closure(): void  $grant
+     */
+    public function run(string $code, Closure $grant): void
+    {
+        $key = hash('sha256', strtolower($code));
+
+        DB::transaction(function () use ($key, $grant): void {
+            DB::table('website_badge_grant_locks')->insertOrIgnore(['lock_key' => $key]);
+            DB::table('website_badge_grant_locks')->where('lock_key', $key)->lockForUpdate()->first();
+
+            try {
+                $grant();
+            } finally {
+                // The database retains this lock until the outermost commit
+                // or rollback, without accumulating one mutex row per code.
+                DB::table('website_badge_grant_locks')->where('lock_key', $key)->delete();
+            }
+        }, attempts: 3);
+    }
+}

--- a/app/Services/Catalog/CatalogReorderService.php
+++ b/app/Services/Catalog/CatalogReorderService.php
@@ -5,6 +5,7 @@ namespace App\Services\Catalog;
 use App\Models\Game\Furniture\CatalogItem;
 use App\Models\Game\Furniture\CatalogPage;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 
 /**
  * Order numbers are written as (i+1)*10 so future drops have gaps to slot into.
@@ -35,12 +36,33 @@ class CatalogReorderService
      */
     public function movePage(int $pageId, int $newParentId, int $insertAtIndex): void
     {
-        $page = CatalogPage::find($pageId);
-        if (! $page) {
-            return;
-        }
+        DB::transaction(function () use ($pageId, $newParentId, $insertAtIndex) {
+            // Serialize hierarchy changes: two individually valid moves must
+            // not combine into a cycle after reading the same old parents.
+            $pages = CatalogPage::query()->orderBy('id')->lockForUpdate()
+                ->get(['id', 'parent_id', 'order_num'])->keyBy('id');
+            $page = $pages->get($pageId);
 
-        DB::transaction(function () use ($page, $newParentId, $insertAtIndex) {
+            if (! $page) {
+                return;
+            }
+
+            $visited = [$pageId => true];
+            $parentId = $newParentId;
+
+            while ($parentId !== -1) {
+                $parent = $pages->get($parentId);
+
+                if ($parent === null || isset($visited[$parentId])) {
+                    throw ValidationException::withMessages([
+                        'parent_id' => __('Choose an existing catalog parent outside this page and its descendants.'),
+                    ]);
+                }
+
+                $visited[$parentId] = true;
+                $parentId = $parent->parent_id;
+            }
+
             $siblings = CatalogPage::query()
                 ->where('parent_id', $newParentId)
                 ->where('id', '!=', $page->id)

--- a/app/Services/Catalog/CatalogTreeService.php
+++ b/app/Services/Catalog/CatalogTreeService.php
@@ -28,9 +28,11 @@ class CatalogTreeService
 
         $byId = CatalogPage::query()->get()->keyBy('id');
         $chain = [];
+        $visited = [];
         $current = $byId[$page->id] ?? null;
 
-        while ($current) {
+        while ($current && ! isset($visited[$current->id])) {
+            $visited[$current->id] = true;
             array_unshift($chain, $current);
             $current = $current->parent_id > 0 ? ($byId[$current->parent_id] ?? null) : null;
         }
@@ -50,7 +52,7 @@ class CatalogTreeService
 
         foreach ($hitIds as $id) {
             $cursor = $byId[$id] ?? null;
-            while ($cursor) {
+            while ($cursor && ! isset($reveal[$cursor->id])) {
                 $reveal[$cursor->id] = $cursor->id;
                 $cursor = $cursor->parent_id > 0 ? ($byId[$cursor->parent_id] ?? null) : null;
             }

--- a/database/migrations/2026_09_07_000000_create_website_badge_grant_locks_table.php
+++ b/database/migrations/2026_09_07_000000_create_website_badge_grant_locks_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('website_badge_grant_locks', function (Blueprint $table): void {
+            $table->char('lock_key', 64)->primary();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('website_badge_grant_locks');
+    }
+};

--- a/tests/Ada/RepositoryConformanceTest.php
+++ b/tests/Ada/RepositoryConformanceTest.php
@@ -21,9 +21,8 @@ use App\Services\HousekeepingPermissionsService;
 use App\Services\PermissionsService;
 use Database\Seeders\HousekeepingPermissionSeeder;
 use Database\Seeders\WebsitePermissionSeeder;
-use Illuminate\Contracts\Cache\LockTimeoutException;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -303,23 +302,14 @@ test('the ada installer waits on a database ada has not finished building', func
     }
 });
 
-test('a grant held up by a competing one still leaves a single row', function () {
-    // The race is read-then-insert with no constraint behind it, so a
-    // sequential duplicate cannot reproduce it. Holding the lock and writing
-    // the row underneath stands in for the competing process: the grant has
-    // to notice the row appeared while it was waiting.
+test('owning a duplicate definition still makes a badge grant a no-op', function () {
     $badges = app(BadgeRepository::class);
     $user = User::factory()->create();
     $code = 'ACH_Race';
 
-    $lock = Cache::lock("ada-badge-grant:{$user->id}:" . sha1($code), 10);
-
-    expect($lock->get())->toBeTrue();
-
+    DB::table('badges')->insert(['code' => $code]);
     $badgeId = DB::table('badges')->insertGetId(['code' => $code]);
     DB::table('player_badges')->insert(['player_id' => $user->id, 'badge_id' => $badgeId, 'slot' => 0]);
-
-    $lock->release();
 
     $badges->grant($user, $code);
 
@@ -327,26 +317,45 @@ test('a grant held up by a competing one still leaves a single row', function ()
         ->and(DB::table('player_badges')->where('player_id', $user->id)->count())->toBe(1);
 });
 
-test('a grant that cannot take the lock does not write a duplicate', function () {
+test('rolling back a badge grant permits a subsequent successful grant', function () {
     $badges = app(BadgeRepository::class);
     $user = User::factory()->create();
     $code = 'ACH_Contended';
 
+    expect(fn () => DB::transaction(function () use ($badges, $user, $code): void {
+        $badges->grant($user, $code);
+
+        throw new RuntimeException('Purchase failed');
+    }))->toThrow(RuntimeException::class, 'Purchase failed');
+
+    expect($badges->codes($user))->toBe([])
+        ->and(DB::table('badges')->where('code', $code)->count())->toBe(0)
+        ->and(DB::table('website_badge_grant_locks')->count())->toBe(0);
+
     $badges->grant($user, $code);
-
-    // A competitor holding the lock past the wait window must make the grant
-    // fail loudly rather than fall through and insert a second row.
-    $lock = Cache::lock("ada-badge-grant:{$user->id}:" . sha1($code), 30);
-    expect($lock->get())->toBeTrue();
-
-    try {
-        expect(fn () => $badges->grant($user, $code))->toThrow(LockTimeoutException::class);
-    } finally {
-        $lock->release();
-    }
 
     expect(DB::table('player_badges')->where('player_id', $user->id)->count())->toBe(1);
 });
+
+test('concurrent Ada grants share one definition through outer transactions', function (bool $differentPlayers) {
+    $result = Process::env([
+        'APP_ENV' => 'testing',
+        'DB_DATABASE' => DB::connection()->getDatabaseName(),
+        'EMULATOR_DRIVER' => 'ada',
+    ])->timeout(15)->run([
+        PHP_BINARY, base_path('tests/Fixtures/concurrent-badge-grants.php'),
+        'ada', 'coordinator', sys_get_temp_dir() . '/atom-badge-race-' . bin2hex(random_bytes(8)),
+        $differentPlayers ? 'different' : 'same',
+    ]);
+
+    expect($result->successful())->toBeTrue($result->errorOutput())
+        ->and(json_decode(trim($result->output()), true, flags: JSON_THROW_ON_ERROR))
+        ->toBe([
+            'driver' => 'ada',
+            'ownership_rows' => $differentPlayers ? 2 : 1,
+            'definition_rows' => 1,
+        ]);
+})->with([true, false]);
 
 test('ada grants a large quantity in bounded chunks', function () {
     $furniture = app(FurnitureRepository::class);

--- a/tests/Feature/Emulator/BadgeManagerTest.php
+++ b/tests/Feature/Emulator/BadgeManagerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Emulator\Contracts\BadgeRepository;
+use App\Filament\Resources\User\Users\Pages\EditUser;
+use App\Filament\Resources\User\Users\RelationManagers\BadgesRelationManager;
+use App\Models\User;
+use Filament\Actions\CreateAction;
+use Filament\Actions\Testing\TestAction;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    installHotel();
+    grantHousekeepingPermission('can_access_housekeeping', 6);
+    grantHousekeepingPermission('edit_user', 6);
+    $this->actingAs(User::factory()->create(['rank' => 7]));
+    Filament::setCurrentPanel(Filament::getPanel('housekeeping'));
+});
+
+test('housekeeping grants offline badges once and preserves equipped ownership', function () {
+    $user = User::factory()->create();
+    $badges = app(BadgeRepository::class);
+    $manager = Livewire::test(BadgesRelationManager::class, [
+        'ownerRecord' => $user,
+        'pageClass' => EditUser::class,
+    ]);
+
+    $manager->callAction(TestAction::make(CreateAction::class)->table(), data: ['badge_code' => 'ADMIN_ONCE'])
+        ->assertHasNoActionErrors();
+
+    expect($badges->codes($user))->toBe(['ADMIN_ONCE']);
+
+    $badges->relation($user)->update(['slot_id' => 3]);
+
+    $manager->callAction(TestAction::make(CreateAction::class)->table(), data: ['badge_code' => 'ADMIN_ONCE'])
+        ->assertHasNoActionErrors();
+
+    expect($badges->codes($user))->toBe(['ADMIN_ONCE'])
+        ->and($badges->relation($user)->value('slot_id'))->toBe(3)
+        ->and($this->rcon->calls)->toBe([]);
+});
+
+test('housekeeping sends online badges only through connected RCON', function (bool $connected) {
+    $user = User::factory()->create(['online' => '1'])->refresh();
+    $this->rcon->connected($connected);
+
+    Livewire::test(BadgesRelationManager::class, [
+        'ownerRecord' => $user,
+        'pageClass' => EditUser::class,
+    ])->callAction(TestAction::make(CreateAction::class)->table(), data: ['badge_code' => 'ADMIN_ONLINE'])
+        ->assertHasNoActionErrors()
+        ->assertNotified($connected ? 'Badge sent through the emulator' : 'RCON is not connected!');
+
+    expect(app(BadgeRepository::class)->codes($user))->toBe([])
+        ->and(array_column($this->rcon->calls, 'method'))->toBe($connected ? ['giveBadge'] : []);
+})->with([true, false]);

--- a/tests/Feature/Emulator/BadgeRepositoryTest.php
+++ b/tests/Feature/Emulator/BadgeRepositoryTest.php
@@ -4,6 +4,8 @@ use App\Emulator\Contracts\BadgeRepository;
 use App\Emulator\Data\OwnedBadge;
 use App\Emulator\Drivers\Arcturus\ArcturusBadgeRepository;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Process;
 
 /**
  * Arcturus half of the badge conformance suite. Ada owns overlapping table
@@ -108,4 +110,18 @@ test('deleting a badge model removes only that row', function () {
 
     expect($badges->relation($user)->pluck('badge_code')->all())->toBe(['ACH_Keep1'])
         ->and($keep->fresh())->not->toBeNull();
+});
+
+test('concurrent Arcturus grants remain unique through outer transactions', function () {
+    $result = Process::env([
+        'APP_ENV' => 'testing',
+        'DB_DATABASE' => DB::connection()->getDatabaseName(),
+        'EMULATOR_DRIVER' => 'arcturus',
+    ])->timeout(15)->run([
+        PHP_BINARY, base_path('tests/Fixtures/concurrent-badge-grants.php'), 'arcturus',
+    ]);
+
+    expect($result->successful())->toBeTrue($result->errorOutput())
+        ->and(json_decode(trim($result->output()), true, flags: JSON_THROW_ON_ERROR))
+        ->toBe(['driver' => 'arcturus', 'ownership_rows' => 1, 'definition_rows' => null]);
 });

--- a/tests/Feature/Installation/InstallerEnvironmentTest.php
+++ b/tests/Feature/Installation/InstallerEnvironmentTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Console\Commands\AtomInstallCommand;
+use Dotenv\Dotenv;
+
+test('installer database credentials round trip through dotenv without interpolation', function (string $password, bool $replaceExisting) {
+    $contents = "EXISTING_VALUE=expanded\nAPP_DEBUG=false\n";
+
+    if ($replaceExisting) {
+        $contents .= "DB_PASSWORD=old-password\n";
+    }
+
+    $replace = new ReflectionMethod(AtomInstallCommand::class, 'replaceEnvValue');
+    $updated = $replace->invoke(new AtomInstallCommand, $contents, 'DB_PASSWORD', $password, '/test/.env');
+    $parsed = Dotenv::parse($updated);
+
+    expect($parsed['DB_PASSWORD'])->toBe($password)
+        ->and($parsed['APP_DEBUG'])->toBe('false')
+        ->and($parsed['EXISTING_VALUE'])->toBe('expanded')
+        ->and($parsed)->toHaveCount(3);
+})->with([
+    'backreference' => ['password$1value'],
+    'dotenv expansion' => ['password${EXISTING_VALUE}'],
+    'comment character' => ['password#value'],
+    'quotes and spaces' => ['password "quoted" value'],
+    'backslashes' => ['password\\value\\'],
+    'literal newline escape' => ['password\\nvalue'],
+    'line injection' => ["password\nAPP_DEBUG=true"],
+    'carriage return' => ["password\rvalue"],
+    'empty' => [''],
+])->with([true, false]);

--- a/tests/Feature/Services/BadgeImportTest.php
+++ b/tests/Feature/Services/BadgeImportTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Models\WebsiteBadge;
+use Illuminate\Support\Facades\File;
+
+beforeEach(function () {
+    $this->badgeImportPath = tempnam(sys_get_temp_dir(), 'atom-badge-import-');
+    setSetting('nitro_external_texts_file', $this->badgeImportPath);
+});
+
+afterEach(function () {
+    File::delete($this->badgeImportPath);
+});
+
+test('badge imports reject malformed JSON and non-object documents', function (string $contents) {
+    File::put($this->badgeImportPath, $contents);
+
+    $this->artisan('import:badge-data')->assertFailed();
+
+    expect(WebsiteBadge::count())->toBe(0);
+})->with(['{"badge_name_TEST":', 'null', '42', '["badge_name_TEST"]']);
+
+test('badge imports update names and descriptions without duplicating definitions', function () {
+    File::put($this->badgeImportPath, json_encode([
+        'badge_name_TEST' => 'First name',
+        'badge_desc_TEST' => 'First description',
+        'unrelated_setting' => ['nested' => true],
+    ], JSON_THROW_ON_ERROR));
+
+    $this->artisan('import:badge-data')->assertSuccessful();
+
+    File::put($this->badgeImportPath, json_encode([
+        'badge_name_TEST' => 'Updated name',
+        'badge_desc_TEST' => 'Updated description',
+    ], JSON_THROW_ON_ERROR));
+
+    $this->artisan('import:badge-data')->assertSuccessful();
+
+    expect(WebsiteBadge::count())->toBe(1)
+        ->and(WebsiteBadge::first()->only(['badge_key', 'badge_name', 'badge_description']))
+        ->toBe([
+            'badge_key' => 'TEST',
+            'badge_name' => 'Updated name',
+            'badge_description' => 'Updated description',
+        ]);
+});
+
+test('a failure in a later badge import chunk preserves all existing definitions', function () {
+    WebsiteBadge::create([
+        'badge_key' => 'TEST0',
+        'badge_name' => 'Original',
+        'badge_description' => 'Original description',
+    ]);
+    $data = [];
+
+    for ($index = 0; $index < 100; $index++) {
+        $data['badge_name_TEST' . $index] = 'Updated name';
+    }
+
+    $data['badge_name_INVALID'] = str_repeat('x', 256);
+    File::put($this->badgeImportPath, json_encode($data, JSON_THROW_ON_ERROR));
+
+    $this->artisan('import:badge-data')->assertFailed();
+
+    expect(WebsiteBadge::count())->toBe(1)
+        ->and(WebsiteBadge::first()->badge_name)->toBe('Original');
+});

--- a/tests/Feature/Services/CatalogHierarchyTest.php
+++ b/tests/Feature/Services/CatalogHierarchyTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Models\Game\Furniture\CatalogPage;
+use App\Services\Catalog\CatalogReorderService;
+use App\Services\Catalog\CatalogTreeService;
+use Illuminate\Validation\ValidationException;
+
+function hierarchyPage(string $caption, int $parentId = -1, int $order = 10): CatalogPage
+{
+    return CatalogPage::create([
+        'caption' => $caption,
+        'caption_save' => $caption,
+        'parent_id' => $parentId,
+        'order_num' => $order,
+    ]);
+}
+
+test('a catalog page cannot move beneath itself or a descendant', function (bool $self) {
+    $parent = hierarchyPage('Parent');
+    $child = hierarchyPage('Child', $parent->id);
+    $destination = $self ? $parent : $child;
+
+    expect(fn () => app(CatalogReorderService::class)->movePage($parent->id, $destination->id, 0))
+        ->toThrow(ValidationException::class);
+
+    expect($parent->refresh()->parent_id)->toBe(-1)
+        ->and($child->refresh()->parent_id)->toBe($parent->id);
+})->with([true, false]);
+
+test('a catalog page cannot move into a missing parent', function () {
+    $page = hierarchyPage('Page');
+
+    expect(fn () => app(CatalogReorderService::class)->movePage($page->id, 999999999, 0))
+        ->toThrow(ValidationException::class);
+
+    expect($page->refresh()->parent_id)->toBe(-1);
+});
+
+test('valid catalog moves preserve sibling ordering and root moves', function () {
+    $parent = hierarchyPage('Parent');
+    $first = hierarchyPage('First', $parent->id);
+    $last = hierarchyPage('Last', $parent->id, 20);
+    $moved = hierarchyPage('Moved');
+    $reorder = app(CatalogReorderService::class);
+
+    $reorder->movePage($moved->id, $parent->id, 1);
+
+    expect(CatalogPage::where('parent_id', $parent->id)->orderBy('order_num')->pluck('id')->all())
+        ->toBe([$first->id, $moved->id, $last->id]);
+
+    $reorder->movePage($moved->id, -1, 0);
+
+    expect($moved->refresh()->parent_id)->toBe(-1)
+        ->and(app(CatalogTreeService::class)->breadcrumb($last))->toHaveCount(2)
+        ->and(app(CatalogTreeService::class)->expandToReveal(collect([$last->id, $first->id])))
+        ->toEqualCanonicalizing([$parent->id, $last->id, $first->id]);
+});
+
+test('existing catalog cycles cannot trap breadcrumbs or ancestor expansion', function () {
+    $first = hierarchyPage('First');
+    $second = hierarchyPage('Second', $first->id);
+    $first->update(['parent_id' => $second->id]);
+    $tree = app(CatalogTreeService::class);
+
+    expect(array_map(fn (CatalogPage $page) => $page->id, $tree->breadcrumb($first)))
+        ->toBe([$second->id, $first->id])
+        ->and($tree->expandToReveal(collect([$first->id, $second->id])))
+        ->toEqualCanonicalizing([$first->id, $second->id]);
+});
+
+test('a catalog page cannot join an existing cycle but can be moved out of one', function () {
+    $first = hierarchyPage('First');
+    $second = hierarchyPage('Second', $first->id);
+    $first->update(['parent_id' => $second->id]);
+    $page = hierarchyPage('Page');
+    $reorder = app(CatalogReorderService::class);
+
+    expect(fn () => $reorder->movePage($page->id, $first->id, 0))
+        ->toThrow(ValidationException::class);
+
+    $reorder->movePage($first->id, -1, 0);
+
+    expect($first->refresh()->parent_id)->toBe(-1)
+        ->and(app(CatalogTreeService::class)->breadcrumb($second))->toHaveCount(2);
+});

--- a/tests/Feature/Shop/ShopPackageTest.php
+++ b/tests/Feature/Shop/ShopPackageTest.php
@@ -4,7 +4,10 @@ use App\Actions\Shop\PurchaseShopPackage;
 use App\Data\RconResponse;
 use App\Emulator\Contracts\CurrencyRepository;
 use App\Enums\CurrencyTypes;
+use App\Exceptions\ShopPurchaseException;
 use App\Models\Shop\WebsiteShopCategory;
+use App\Models\Shop\WebsiteShopItem;
+use App\Models\Shop\WebsiteShopPackage;
 use App\Models\Shop\WebsiteShopPurchase;
 use App\Models\User;
 use Database\Seeders\WebsiteShopSeeder;
@@ -146,6 +149,57 @@ test('a gifted package delivers to the recipient and records the gift', function
         ->and((int) $recipient->refresh()->credits)->toBe($recipientCredits + 200)
         ->and(WebsiteShopPurchase::where('user_id', $buyer->id)->where('gifted_to', $recipient->id)->count())->toBe(1);
 });
+
+test('a package that stops being giftable cannot be delivered from a stale model', function () {
+    installHotel();
+
+    $buyer = User::factory()->create(['website_balance' => 10000]);
+    $recipient = User::factory()->create();
+    $package = makePackage(['is_giftable' => true, 'stock' => 1]);
+    $recipientCredits = (int) $recipient->credits;
+
+    WebsiteShopPackage::whereKey($package->id)->update(['is_giftable' => false]);
+
+    expect(fn () => app(PurchaseShopPackage::class)->execute($buyer, $package, $recipient->username))
+        ->toThrow(ShopPurchaseException::class, 'This package is not giftable');
+
+    expect((int) $buyer->refresh()->website_balance)->toBe(10000)
+        ->and((int) $recipient->refresh()->credits)->toBe($recipientCredits)
+        ->and($package->refresh()->stock)->toBe(1)
+        ->and(WebsiteShopPurchase::count())->toBe(0);
+});
+
+test('invalid item numbers reject the purchase and roll back earlier rewards', function (string $type, string $value, int $quantity) {
+    installHotel();
+
+    $buyer = User::factory()->create(['website_balance' => 10000, 'rank' => 1]);
+    $package = makePackage(['stock' => 1]);
+    $credits = (int) $buyer->credits;
+    $rank = (int) $buyer->rank;
+    $item = WebsiteShopItem::create([
+        'name' => 'Misconfigured reward',
+        'type' => $type,
+        'type_value' => $value,
+        'is_active' => true,
+    ]);
+    $package->items()->attach($item->id, ['quantity' => $quantity]);
+
+    $this->actingAs($buyer)
+        ->post(route('shop.buy-package', $package))
+        ->assertSessionHasErrors('message');
+
+    expect((int) $buyer->refresh()->website_balance)->toBe(10000)
+        ->and((int) $buyer->credits)->toBe($credits)
+        ->and((int) $buyer->rank)->toBe($rank)
+        ->and($package->refresh()->stock)->toBe(1)
+        ->and(WebsiteShopPurchase::count())->toBe(0);
+})->with([
+    'currency suffix' => ['currency', 'credits:50bad', 1],
+    'fractional currency' => ['currency', 'credits:50.5', 1],
+    'furniture suffix' => ['furniture', '230bad', 1],
+    'rank suffix' => ['rank', '5bad', 1],
+    'currency multiplication overflow' => ['currency', 'credits:' . PHP_INT_MAX, 2],
+]);
 
 test('an online recipient is disconnected before atomic delivery', function () {
     installHotel();

--- a/tests/Fixtures/concurrent-badge-grants.php
+++ b/tests/Fixtures/concurrent-badge-grants.php
@@ -1,0 +1,92 @@
+<?php
+
+// Separate processes reproduce grants whose surrounding transactions overlap.
+// Clone the real badge table shapes so DDL and committed writes never touch
+// the test suite's player data or its RefreshDatabase transaction.
+
+use App\Emulator\Drivers\Ada\AdaBadgeRepository;
+use App\Emulator\Drivers\Arcturus\ArcturusBadgeRepository;
+use App\Models\User;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\Process\Process;
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+$app = require dirname(__DIR__, 2) . '/bootstrap/app.php';
+$app->make(Kernel::class)->bootstrap();
+$driver = $argv[1];
+$differentPlayers = ($argv[4] ?? 'same') === 'different';
+$mode = $argv[2] ?? 'coordinator';
+$directory = $argv[3] ?? sys_get_temp_dir() . '/atom-badge-race-' . uniqid();
+$prefix = 'badge_race_' . substr(hash('sha256', $directory), 0, 12) . '_';
+$tables = $driver === 'ada' ? ['badges', 'player_badges', 'website_badge_grant_locks'] : ['users_badges', 'website_badge_grant_locks'];
+$connection = DB::connection();
+
+if ($mode === 'coordinator') {
+    mkdir($directory, 0700);
+    foreach ($tables as $table) {
+        $connection->statement("DROP TABLE IF EXISTS `{$prefix}{$table}`");
+        $connection->statement("CREATE TABLE `{$prefix}{$table}` LIKE `{$table}`");
+    }
+    try {
+        $first = new Process([PHP_BINARY, __FILE__, $driver, 'first', $directory, $differentPlayers ? 'different' : 'same'], timeout: 10);
+        $second = new Process([PHP_BINARY, __FILE__, $driver, 'second', $directory, $differentPlayers ? 'different' : 'same'], timeout: 10);
+        $first->start();
+        $second->start();
+        $first->wait();
+        $second->wait();
+        if (! $first->isSuccessful() || ! $second->isSuccessful() || trim($first->getOutput()) !== 'completed' || trim($second->getOutput()) !== 'completed') {
+            throw new RuntimeException($first->getOutput() . $first->getErrorOutput() . $second->getOutput() . $second->getErrorOutput());
+        }
+        $ownedTable = $driver === 'ada' ? 'player_badges' : 'users_badges';
+        $owned = $connection->table($prefix . $ownedTable)->count();
+        $definitions = $driver === 'ada' ? $connection->table($prefix . 'badges')->count() : null;
+        echo json_encode(['driver' => $driver, 'ownership_rows' => $owned, 'definition_rows' => $definitions]) . PHP_EOL;
+    } finally {
+        if (isset($first)) {
+            $first->stop(0.1);
+        }
+        if (isset($second)) {
+            $second->stop(0.1);
+        }
+        foreach ($tables as $table) {
+            $connection->statement("DROP TABLE IF EXISTS `{$prefix}{$table}`");
+        }
+        foreach (glob($directory . '/*') as $file) {
+            unlink($file);
+        }
+        rmdir($directory);
+    }
+    exit;
+}
+
+$connection->setTablePrefix($prefix);
+$user = new User;
+$user->forceFill(['id' => $differentPlayers && $mode === 'second' ? 9999998 : 9999999]);
+$badges = $driver === 'ada' ? new AdaBadgeRepository : new ArcturusBadgeRepository;
+$waitFor = function (string $file): void {
+    $deadline = microtime(true) + 5;
+    while (! is_file($file)) {
+        if (microtime(true) > $deadline) {
+            throw new RuntimeException('Timed out waiting for competing grant.');
+        }
+        usleep(10000);
+    }
+};
+if ($mode === 'first') {
+    DB::transaction(function () use ($badges, $user, $directory, $waitFor): void {
+        $badges->grant($user, 'ACH_Concurrent');
+        touch($directory . '/first-granted');
+        $waitFor($directory . '/second-started');
+        usleep(300000);
+    }, attempts: 3);
+} else {
+    $waitFor($directory . '/first-granted');
+    DB::transaction(function () use ($badges, $user, $directory, $driver): void {
+        DB::table($driver === 'ada' ? 'player_badges' : 'users_badges')->count();
+        touch($directory . '/second-started');
+        $badges->grant($user, 'ACH_Concurrent');
+    }, attempts: 3);
+}
+
+echo 'completed';


### PR DESCRIPTION
## Why

Prevent invalid shop rewards, cyclic catalog trees, partial badge imports, and concurrent duplicate grants. Preserve the combined domain fixes alongside the existing individual audit PRs.
