### PR TITLE
fix(auth): require two-factor verification in housekeeping

### DIFF
--- a/app/Actions/Fortify/Controllers/TwoFactorAuthenticatedSessionController.php
+++ b/app/Actions/Fortify/Controllers/TwoFactorAuthenticatedSessionController.php
@@ -2,10 +2,10 @@
 
 namespace App\Actions\Fortify\Controllers;
 
+use App\Actions\Fortify\VerifyTwoFactorCode;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Routing\Controller;
 use Illuminate\Validation\ValidationException;
-use Laravel\Fortify\Events\RecoveryCodeReplaced;
 use Laravel\Fortify\Http\Requests\TwoFactorLoginRequest;
 use Laravel\Fortify\Http\Responses\TwoFactorLoginResponse;
 
@@ -31,19 +31,17 @@ class TwoFactorAuthenticatedSessionController extends Controller
     /**
      * Attempt to authenticate a new session using the two factor authentication code.
      */
-    public function store(TwoFactorLoginRequest $request): TwoFactorLoginResponse
+    public function store(TwoFactorLoginRequest $request, VerifyTwoFactorCode $verify): TwoFactorLoginResponse
     {
         $user = $request->challengedUser();
 
-        if ($code = $request->validRecoveryCode()) {
-            $user->replaceRecoveryCode($code);
-
-            event(new RecoveryCodeReplaced($user, $code));
-        } elseif (! $request->hasValidCode()) {
+        if (! $verify($user, $request->input('code'), $request->input('recovery_code'))) {
             throw ValidationException::withMessages([
                 'code' => __('Invalid Two Factor Authentication code'),
             ]);
         }
+
+        $request->session()->forget('login.id');
 
         $this->guard->login($user, $request->remember());
 

--- a/app/Actions/Fortify/VerifyTwoFactorCode.php
+++ b/app/Actions/Fortify/VerifyTwoFactorCode.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Actions\Fortify;
+
+use App\Models\User;
+use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
+use Laravel\Fortify\Fortify;
+use SensitiveParameter;
+
+class VerifyTwoFactorCode
+{
+    public function __construct(private TwoFactorAuthenticationProvider $provider) {}
+
+    public function __invoke(User $user, #[SensitiveParameter] ?string $code, #[SensitiveParameter] ?string $recoveryCode = null): bool
+    {
+        $secret = $user->two_factor_secret;
+
+        if (! $user->hasEnabledTwoFactorAuthentication() || $secret === null) {
+            return false;
+        }
+
+        if (filled($recoveryCode) && $user->getConnection()->transaction(function () use ($user, $recoveryCode): bool {
+            $user = $user->newQuery()->whereKey($user->getKey())->lockForUpdate()->first();
+
+            if (! $user?->hasEnabledTwoFactorAuthentication() || blank($user->two_factor_recovery_codes)) {
+                return false;
+            }
+
+            foreach ($user->recoveryCodes() as $storedCode) {
+                if (hash_equals($storedCode, $recoveryCode)) {
+                    $user->replaceRecoveryCode($storedCode);
+
+                    return true;
+                }
+            }
+
+            return false;
+        })) {
+            return true;
+        }
+
+        return filled($code) && $this->provider->verify(
+            Fortify::currentEncrypter()->decrypt($secret),
+            $code,
+        );
+    }
+}

--- a/app/Filament/Auth/FortifyTwoFactorAuthentication.php
+++ b/app/Filament/Auth/FortifyTwoFactorAuthentication.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Filament\Auth;
+
+use App\Actions\Fortify\VerifyTwoFactorCode;
+use App\Filament\Pages\TwoFactorAuthentication;
+use App\Models\User;
+use Closure;
+use Filament\Actions\Action;
+use Filament\Auth\MultiFactor\Contracts\MultiFactorAuthenticationProvider;
+use Filament\Forms\Components\TextInput;
+use Illuminate\Contracts\Auth\Authenticatable;
+use SensitiveParameter;
+
+class FortifyTwoFactorAuthentication implements MultiFactorAuthenticationProvider
+{
+    public function getId(): string
+    {
+        return 'fortify';
+    }
+
+    public function getLoginFormLabel(): string
+    {
+        return __('Authenticator app');
+    }
+
+    public function isEnabled(Authenticatable $user): bool
+    {
+        return $user instanceof User && $user->hasEnabledTwoFactorAuthentication();
+    }
+
+    public function getManagementSchemaComponents(): array
+    {
+        return [Action::make('manageTwoFactorAuthentication')
+            ->label(__('Manage two-factor authentication'))
+            ->url(TwoFactorAuthentication::getUrl())];
+    }
+
+    public function getChallengeFormComponents(Authenticatable $user): array
+    {
+        return [TextInput::make('code')
+            ->label(__('Authentication or recovery code'))
+            ->autocomplete('one-time-code')
+            ->required()
+            ->maxLength(255)
+            ->rule(fn (): Closure => function (string $attribute, #[SensitiveParameter] mixed $value, Closure $fail) use ($user): void {
+                if ($user instanceof User && is_string($value) && app(VerifyTwoFactorCode::class)($user, $value, $value)) {
+                    return;
+                }
+
+                $fail(__('Invalid Two Factor Authentication code'));
+            })];
+    }
+}

--- a/app/Filament/Pages/TwoFactorAuthentication.php
+++ b/app/Filament/Pages/TwoFactorAuthentication.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Validation\ValidationException;
+use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
+use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+
+class TwoFactorAuthentication extends Page
+{
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-shield-check';
+
+    protected string $view = 'filament.pages.two-factor-authentication';
+
+    public string $currentPassword = '';
+
+    public string $code = '';
+
+    public function enable(): void
+    {
+        $this->throttle();
+        $this->validate(['currentPassword' => ['required', 'current_password:web']]);
+
+        app(EnableTwoFactorAuthentication::class)($this->currentUser());
+        $this->reset('currentPassword', 'code');
+    }
+
+    public function confirm(): void
+    {
+        $this->throttle();
+        $this->validate(['code' => ['required', 'string', 'size:6']]);
+
+        app(ConfirmTwoFactorAuthentication::class)($this->currentUser(), $this->code);
+        $this->reset('code');
+
+        Notification::make()->success()->title(__('Two-factor authentication has been confirmed.'))->send();
+    }
+
+    public function disable(): void
+    {
+        $this->throttle();
+        $this->validate(['currentPassword' => ['required', 'current_password:web']]);
+
+        app(DisableTwoFactorAuthentication::class)($this->currentUser());
+        $this->reset('currentPassword', 'code');
+    }
+
+    protected function currentUser(): User
+    {
+        $user = Filament::auth()->user();
+        abort_unless($user instanceof User, 403);
+
+        return $user->refresh();
+    }
+
+    protected function throttle(): void
+    {
+        $key = 'housekeeping-two-factor-settings:' . $this->currentUser()->getAuthIdentifier();
+
+        if (RateLimiter::tooManyAttempts($key, 6)) {
+            throw ValidationException::withMessages([
+                'code' => __('Too many attempts. Please try again later.'),
+            ]);
+        }
+
+        RateLimiter::hit($key);
+    }
+
+    protected function getViewData(): array
+    {
+        return ['user' => $this->currentUser()];
+    }
+}

--- a/app/Http/Middleware/ForceStaffTwoFactorMiddleware.php
+++ b/app/Http/Middleware/ForceStaffTwoFactorMiddleware.php
@@ -22,6 +22,7 @@ class ForceStaffTwoFactorMiddleware
             'user.two-factor.enable',
             'two-factor.verify',
             'user.two-factor.disable',
+            'filament.housekeeping.pages.two-factor-authentication',
         ];
 
         if (
@@ -29,7 +30,9 @@ class ForceStaffTwoFactorMiddleware
             && ! $user->hasEnabledTwoFactorAuthentication()
             && ! $request->routeIs(...$allowedRoutes)
         ) {
-            return to_route('settings.two-factor');
+            return to_route($request->routeIs('filament.housekeeping.*')
+                ? 'filament.housekeeping.pages.two-factor-authentication'
+                : 'settings.two-factor');
         }
 
         return $next($request);

--- a/app/Providers/Filament/AdminFilamentPanelProvider.php
+++ b/app/Providers/Filament/AdminFilamentPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Auth\FortifyTwoFactorAuthentication;
 use App\Filament\Pages\Login;
 use App\Http\Middleware\AuthenticateHousekeepingSession;
 use App\Http\Middleware\BannedMiddleware;
@@ -32,6 +33,7 @@ class AdminFilamentPanelProvider extends PanelProvider
             ->path('housekeeping')
             ->strictAuthorization()
             ->login(Login::class)
+            ->multiFactorAuthentication(app(FortifyTwoFactorAuthentication::class))
             ->viteTheme('resources/css/filament/housekeeping/theme.css')
             ->colors([
                 'primary' => Color::Amber,

--- a/resources/views/filament/pages/two-factor-authentication.blade.php
+++ b/resources/views/filament/pages/two-factor-authentication.blade.php
@@ -1,0 +1,43 @@
+<x-filament-panels::page>
+    <x-filament::section>
+        @if ($user->hasEnabledTwoFactorAuthentication())
+            <p>{{ __('Two-factor authentication is enabled. Keep these recovery codes somewhere safe. Each code can be used once.') }}</p>
+            <ul class="mt-4 space-y-1 font-mono">
+                @foreach ($user->recoveryCodes() as $recoveryCode)
+                    <li>{{ $recoveryCode }}</li>
+                @endforeach
+            </ul>
+            <x-filament::button tag="a" :href="\App\Filament\Pages\Dashboard::getUrl()" class="mt-4">
+                {{ __('Continue to housekeeping') }}
+            </x-filament::button>
+        @elseif ($user->two_factor_secret)
+            <p>{{ __('Scan this QR code with your authenticator app, then enter the six-digit code to finish setup.') }}</p>
+            <div class="my-4 w-fit bg-white p-4">{!! $user->twoFactorQrCodeSvg() !!}</div>
+            <form wire:submit="confirm" class="space-y-4">
+                <label for="two-factor-code">{{ __('Authentication code') }}</label>
+                <x-filament::input.wrapper>
+                    <x-filament::input id="two-factor-code" wire:model="code" autocomplete="one-time-code" inputmode="numeric" maxlength="6" required />
+                </x-filament::input.wrapper>
+                <x-filament::button type="submit">{{ __('Confirm two-factor authentication') }}</x-filament::button>
+            </form>
+        @else
+            <p>{{ __('Protect your account with an authenticator app. Your existing account and housekeeping use the same two-factor authentication.') }}</p>
+        @endif
+
+        <form wire:submit="{{ $user->two_factor_secret ? 'disable' : 'enable' }}" class="mt-6 space-y-4">
+            <label for="two-factor-password">{{ __('Current password') }}</label>
+            <x-filament::input.wrapper>
+                <x-filament::input id="two-factor-password" type="password" wire:model="currentPassword" autocomplete="current-password" required />
+            </x-filament::input.wrapper>
+            @error('currentPassword')
+                <p role="alert">{{ $message }}</p>
+            @enderror
+            <x-filament::button type="submit" :color="$user->two_factor_secret ? 'danger' : 'primary'">
+                {{ $user->two_factor_secret ? __('Disable two-factor authentication') : __('Enable two-factor authentication') }}
+            </x-filament::button>
+        </form>
+        @error('code')
+            <p role="alert" class="mt-4">{{ $message }}</p>
+        @enderror
+    </x-filament::section>
+</x-filament-panels::page>

--- a/tests/Ada/HousekeepingTwoFactorTest.php
+++ b/tests/Ada/HousekeepingTwoFactorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Filament\Pages\Login;
+use App\Filament\Pages\TwoFactorAuthentication;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use Livewire\Livewire;
+
+test('Ada housekeeping challenges and consumes the same Fortify recovery codes', function () {
+    installHotel();
+    grantHousekeepingPermission('can_access_housekeeping', 6);
+    setSetting('force_staff_2fa', '0');
+    Filament::setCurrentPanel(Filament::getPanel('housekeeping'));
+    $staff = User::factory()->create(['rank' => 6]);
+    app(EnableTwoFactorAuthentication::class)($staff);
+    $staff->forceFill(['two_factor_confirmed_at' => now()])->save();
+    $recoveryCode = $staff->recoveryCodes()[0];
+
+    $login = Livewire::test(Login::class)
+        ->set('data.username', $staff->username)
+        ->set('data.password', 'password')
+        ->call('authenticate');
+    $this->assertGuest();
+
+    $login->set('data.multiFactor.fortify.code', 'invalid')
+        ->call('authenticate')->assertHasErrors('data.multiFactor.fortify.code');
+    $this->assertGuest();
+
+    $login->set('data.multiFactor.fortify.code', $recoveryCode)
+        ->call('authenticate')->assertHasNoErrors();
+    $this->assertAuthenticatedAs($staff);
+    expect($staff->fresh()->recoveryCodes())->not->toContain($recoveryCode);
+
+    $this->get(TwoFactorAuthentication::getUrl())->assertOk();
+});

--- a/tests/Feature/HousekeepingAccessTest.php
+++ b/tests/Feature/HousekeepingAccessTest.php
@@ -100,7 +100,7 @@ test('forced staff two-factor authentication also protects housekeeping', functi
 
     $this->actingAs($staff)
         ->get('/housekeeping')
-        ->assertRedirect(route('settings.two-factor'));
+        ->assertRedirect(route('filament.housekeeping.pages.two-factor-authentication'));
 });
 
 test('banned staff cannot access housekeeping', function () {

--- a/tests/Feature/HousekeepingTwoFactorTest.php
+++ b/tests/Feature/HousekeepingTwoFactorTest.php
@@ -1,0 +1,243 @@
+<?php
+
+use App\Filament\Pages\Login;
+use App\Filament\Pages\TwoFactorAuthentication;
+use App\Models\User;
+use Filament\Auth\MultiFactor\MultiFactorChallenge;
+use Filament\Facades\Filament;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use Laravel\Fortify\Fortify;
+use Livewire\Livewire;
+use PragmaRX\Google2FA\Google2FA;
+
+beforeEach(function () {
+    installHotel();
+    grantHousekeepingPermission('can_access_housekeeping', 6);
+    setSetting('force_staff_2fa', '0');
+    Filament::setCurrentPanel(Filament::getPanel('housekeeping'));
+    $this->staff = User::factory()->create(['rank' => 6]);
+    app(EnableTwoFactorAuthentication::class)($this->staff);
+    $this->staff->forceFill(['two_factor_confirmed_at' => now()])->save();
+});
+
+test('housekeeping accepts a Fortify authenticator code and establishes the remembered session only afterwards', function () {
+    $login = Livewire::test(Login::class)
+        ->set('data.username', $this->staff->username)
+        ->set('data.password', 'password')
+        ->set('data.remember', true)
+        ->call('authenticate');
+
+    $sessionId = session()->getId();
+    $secret = Fortify::currentEncrypter()->decrypt($this->staff->two_factor_secret);
+    $code = app(Google2FA::class)->getCurrentOtp($secret);
+
+    $login->set('data.multiFactor.fortify.code', $code)
+        ->call('authenticate')
+        ->assertHasNoErrors()
+        ->assertRedirect('/housekeeping');
+
+    $this->assertAuthenticatedAs($this->staff);
+    expect($this->staff->fresh()->getRememberToken())->not->toBeNull()
+        ->and(session()->getId())->not->toBe($sessionId)
+        ->and(session()->has('password_hash_web'))->toBeTrue();
+
+    $this->post(route('filament.housekeeping.auth.logout'))->assertRedirect();
+    $this->assertGuest();
+    expect(session()->has('password_hash_web'))->toBeFalse();
+});
+
+test('missing and invalid factors leave housekeeping guests unauthenticated', function (string $code) {
+    Livewire::test(Login::class)
+        ->set('data.username', $this->staff->username)
+        ->set('data.password', 'password')
+        ->call('authenticate')
+        ->set('data.multiFactor.fortify.code', $code)
+        ->call('authenticate')
+        ->assertHasErrors('data.multiFactor.fortify.code');
+
+    $this->assertGuest();
+})->with(['missing' => '', 'invalid' => 'invalid-recovery-code']);
+
+test('invalid passwords do not start the housekeeping factor challenge', function () {
+    Livewire::test(Login::class)
+        ->set('data.username', $this->staff->username)
+        ->set('data.password', 'incorrect')
+        ->call('authenticate')
+        ->assertHasErrors('data.username')
+        ->assertSet('userUndertakingMultiFactorAuthentication', null);
+
+    $this->assertGuest();
+});
+
+test('housekeeping preserves login for users without confirmed two-factor authentication', function (bool $pending) {
+    $this->staff->forceFill([
+        'two_factor_confirmed_at' => null,
+        'two_factor_secret' => $pending ? $this->staff->two_factor_secret : null,
+    ])->save();
+
+    Livewire::test(Login::class)
+        ->set('data.username', $this->staff->username)
+        ->set('data.password', 'password')
+        ->call('authenticate')
+        ->assertHasNoErrors();
+
+    $this->assertAuthenticatedAs($this->staff);
+})->with(['unenrolled' => false, 'pending confirmation' => true]);
+
+test('a recovery code consumed by housekeeping cannot be reused through Fortify', function () {
+    $recoveryCode = $this->staff->recoveryCodes()[0];
+
+    Livewire::test(Login::class)
+        ->set('data.username', $this->staff->username)
+        ->set('data.password', 'password')
+        ->call('authenticate')
+        ->set('data.multiFactor.fortify.code', $recoveryCode)
+        ->call('authenticate')
+        ->assertHasNoErrors();
+
+    $this->assertAuthenticatedAs($this->staff);
+    expect($this->staff->fresh()->recoveryCodes())->not->toContain($recoveryCode);
+    auth()->logout();
+
+    $this->post(route('login.store'), ['username' => $this->staff->username, 'password' => 'password'])
+        ->assertRedirect(route('two-factor.login'));
+    $this->post('/two-factor-challenge', ['recovery_code' => $recoveryCode])->assertSessionHasErrors('code');
+    $this->assertGuest();
+    $this->post('/two-factor-challenge', ['recovery_code' => $this->staff->fresh()->recoveryCodes()[0]])
+        ->assertSessionMissing('login.id');
+    $this->assertAuthenticatedAs($this->staff);
+});
+
+test('a recovery code consumed by Fortify cannot be reused through housekeeping', function () {
+    $recoveryCode = $this->staff->recoveryCodes()[0];
+    $this->post(route('login.store'), ['username' => $this->staff->username, 'password' => 'password']);
+    $this->post('/two-factor-challenge', ['recovery_code' => $recoveryCode]);
+    $this->assertAuthenticatedAs($this->staff);
+    auth()->logout();
+
+    Livewire::test(Login::class)
+        ->set('data.username', $this->staff->username)
+        ->set('data.password', 'password')
+        ->call('authenticate')
+        ->set('data.multiFactor.fortify.code', $recoveryCode)
+        ->call('authenticate')
+        ->assertHasErrors('data.multiFactor.fortify.code');
+
+    $this->assertGuest();
+});
+
+test('housekeeping and Fortify share authenticator code replay protection', function () {
+    $secret = Fortify::currentEncrypter()->decrypt($this->staff->two_factor_secret);
+    $code = app(Google2FA::class)->getCurrentOtp($secret);
+
+    Livewire::test(Login::class)
+        ->set('data.username', $this->staff->username)
+        ->set('data.password', 'password')
+        ->call('authenticate')
+        ->set('data.multiFactor.fortify.code', $code)
+        ->call('authenticate')->assertHasNoErrors();
+    $this->assertAuthenticatedAs($this->staff);
+    auth()->logout();
+
+    $this->post(route('login.store'), ['username' => $this->staff->username, 'password' => 'password']);
+    $this->post('/two-factor-challenge', ['code' => $code])->assertSessionHasErrors('code');
+    $this->assertGuest();
+});
+
+test('a throttled housekeeping challenge does not consume a valid recovery code', function () {
+    $login = Livewire::test(Login::class)
+        ->set('data.username', $this->staff->username)
+        ->set('data.password', 'password')
+        ->call('authenticate');
+    $recoveryCode = $this->staff->recoveryCodes()[0];
+
+    foreach (range(1, 5) as $attempt) {
+        MultiFactorChallenge::make()->hitRateLimiter($this->staff);
+    }
+
+    $login->set('data.multiFactor.fortify.code', $recoveryCode)->call('authenticate');
+    $this->assertGuest();
+    expect($this->staff->fresh()->recoveryCodes())->toContain($recoveryCode);
+});
+
+test('changing the challenged account does not authenticate with the first accounts factor', function () {
+    $other = User::factory()->create(['rank' => 6]);
+    app(EnableTwoFactorAuthentication::class)($other);
+    $other->forceFill(['two_factor_confirmed_at' => now()])->save();
+
+    $login = Livewire::test(Login::class)
+        ->set('data.username', $this->staff->username)
+        ->set('data.password', 'password')
+        ->call('authenticate')
+        ->set('data.username', $other->username)
+        ->set('data.multiFactor.fortify.code', $this->staff->recoveryCodes()[0])
+        ->call('authenticate');
+
+    $this->assertGuest();
+    $login->set('data.multiFactor.fortify.code', $this->staff->recoveryCodes()[0])
+        ->call('authenticate')
+        ->assertHasErrors('data.multiFactor.fortify.code');
+    $this->assertGuest();
+});
+
+test('housekeeping rechecks the password and panel access before accepting the factor', function (string $change) {
+    $login = Livewire::test(Login::class)
+        ->set('data.username', $this->staff->username)
+        ->set('data.password', 'password')
+        ->call('authenticate');
+
+    $this->staff->forceFill($change === 'password' ? ['password' => 'changed-password'] : ['rank' => 1])->save();
+
+    $login->set('data.multiFactor.fortify.code', $this->staff->recoveryCodes()[0])
+        ->call('authenticate')
+        ->assertHasErrors('data.username');
+    $this->assertGuest();
+})->with(['password', 'permission']);
+
+test('housekeeping two-factor setup uses the existing Fortify enrollment and requires the current password', function () {
+    $this->staff->forceFill([
+        'two_factor_secret' => null,
+        'two_factor_recovery_codes' => null,
+        'two_factor_confirmed_at' => null,
+    ])->save();
+    $this->actingAs($this->staff);
+    setSetting('force_staff_2fa', '1');
+
+    $this->get('/housekeeping')->assertRedirect(TwoFactorAuthentication::getUrl());
+    $this->get(TwoFactorAuthentication::getUrl())->assertOk();
+
+    $page = Livewire::test(TwoFactorAuthentication::class)
+        ->set('currentPassword', 'incorrect')
+        ->call('enable')
+        ->assertHasErrors('currentPassword');
+    expect($this->staff->fresh()->two_factor_secret)->toBeNull();
+
+    $page->set('currentPassword', 'password')->call('enable')->assertHasNoErrors()->assertSee('<svg', false);
+    expect($this->staff->fresh()->two_factor_confirmed_at)->toBeNull();
+
+    $page->set('code', 'bad')->call('confirm')->assertHasErrors('code');
+    $secret = Fortify::currentEncrypter()->decrypt($this->staff->fresh()->two_factor_secret);
+    $page->set('code', app(Google2FA::class)->getCurrentOtp($secret))
+        ->call('confirm')->assertHasNoErrors()
+        ->assertSee($this->staff->fresh()->recoveryCodes()[0]);
+    expect($this->staff->fresh()->hasEnabledTwoFactorAuthentication())->toBeTrue();
+
+    $page->set('currentPassword', 'incorrect')->call('disable')->assertHasErrors('currentPassword');
+    expect($this->staff->fresh()->hasEnabledTwoFactorAuthentication())->toBeTrue();
+    $page->set('currentPassword', 'password')->call('disable')->assertHasNoErrors();
+    expect($this->staff->fresh()->two_factor_secret)->toBeNull();
+});
+
+test('housekeeping requires a second factor before authenticating enrolled staff', function () {
+    $rememberToken = $this->staff->getRememberToken();
+
+    Livewire::test(Login::class)
+        ->set('data.username', $this->staff->username)
+        ->set('data.password', 'password')
+        ->set('data.remember', true)
+        ->call('authenticate')
+        ->assertHasNoErrors();
+
+    $this->assertGuest();
+    expect($this->staff->fresh()->getRememberToken())->toBe($rememberToken);
+});

--- a/tests/Feature/Middleware/LivewireAccessGatesTest.php
+++ b/tests/Feature/Middleware/LivewireAccessGatesTest.php
@@ -45,6 +45,10 @@ beforeEach(function () {
 
 test('livewire actions honor access restrictions introduced after page load', function (string $gate, string $redirect, string $surface) {
     $housekeeping = $surface === 'housekeeping';
+    if ($housekeeping && $gate === 'two-factor') {
+        $redirect = 'filament.housekeeping.pages.two-factor-authentication';
+    }
+
     $page = $this->get($housekeeping
         ? '/housekeeping/website/articles/' . $this->article->id . '/edit'
         : route('article.show', $this->article->slug))->assertOk();


### PR DESCRIPTION
## Why

Housekeeping accepted passwords without challenging accounts enrolled in two-factor authentication. Require the existing Fortify factor at login and provide enrollment inside housekeeping.

## Testing

- [ ] Open `/housekeeping/login` with a staff account enrolled in 2FA; confirm the password alone does not log in, an invalid code fails, and a valid authenticator or recovery code succeeds.
- [ ] Open `/housekeeping/two-factor-authentication` to enroll using the QR code, confirm it, and verify the next login requires a code.
